### PR TITLE
chore: remove regex dependency from veneer-adapters

### DIFF
--- a/crates/veneer-adapters/Cargo.toml
+++ b/crates/veneer-adapters/Cargo.toml
@@ -11,7 +11,6 @@ oxc_parser = { workspace = true }
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_span = { workspace = true }
-regex = { workspace = true }
 thiserror = { workspace = true }
 walkdir = { workspace = true }
 


### PR DESCRIPTION
## Summary
- Remove `regex` from `veneer-adapters/Cargo.toml` -- no longer used after oxc AST migration (#8, #9)
- Kept in workspace `[workspace.dependencies]` since `veneer-static` still uses it

Closes #10

## Test plan
- [x] `cargo test -p veneer-adapters` -- 37 tests pass
- [x] `cargo clippy -p veneer-adapters -- -D warnings` clean
- [x] Full workspace builds (`veneer-static` still resolves regex from workspace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)