### PR TITLE
feat: add configurable ComponentConventions for extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2371,7 +2371,7 @@ dependencies = [
  "oxc_parser",
  "oxc_span",
  "pretty_assertions",
- "regex",
+ "serde",
  "tempfile",
  "thiserror",
  "walkdir",

--- a/crates/veneer-adapters/Cargo.toml
+++ b/crates/veneer-adapters/Cargo.toml
@@ -11,6 +11,7 @@ oxc_parser = { workspace = true }
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_span = { workspace = true }
+serde = { workspace = true }
 thiserror = { workspace = true }
 walkdir = { workspace = true }
 

--- a/crates/veneer-adapters/src/conventions.rs
+++ b/crates/veneer-adapters/src/conventions.rs
@@ -1,0 +1,56 @@
+//! Configurable conventions for component extraction.
+//!
+//! Allows users to specify which variable names map to variant records,
+//! size records, base classes, and other component structure elements,
+//! making veneer work with any design system naming convention.
+
+use serde::Deserialize;
+
+/// Configuration for how component structure is identified in source code.
+///
+/// Each field contains a list of variable names or attribute names that
+/// veneer should recognize. The defaults match the conventions used by
+/// the original hardcoded extraction logic.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct ComponentConventions {
+    /// Variable names that hold variant-to-class mappings (e.g., "variantClasses").
+    pub variant_records: Vec<String>,
+
+    /// Variable names that hold size-to-class mappings (e.g., "sizeClasses").
+    pub size_records: Vec<String>,
+
+    /// Variable names that hold base CSS classes (e.g., "baseClasses").
+    pub base_class_vars: Vec<String>,
+
+    /// Variable names that hold disabled-state CSS classes (e.g., "disabledClasses").
+    pub disabled_class_vars: Vec<String>,
+
+    /// Prop names to exclude from observed attributes (e.g., "children", "className").
+    pub excluded_props: Vec<String>,
+
+    /// Attribute names to check as fallback when no interface or destructuring is found.
+    pub fallback_attributes: Vec<String>,
+}
+
+impl Default for ComponentConventions {
+    fn default() -> Self {
+        Self {
+            variant_records: vec!["variantClasses".to_string()],
+            size_records: vec!["sizeClasses".to_string()],
+            base_class_vars: vec!["baseClasses".to_string()],
+            disabled_class_vars: vec!["disabledClasses".to_string(), "disabledCls".to_string()],
+            excluded_props: vec![
+                "children".to_string(),
+                "className".to_string(),
+                "style".to_string(),
+            ],
+            fallback_attributes: vec![
+                "variant".to_string(),
+                "size".to_string(),
+                "disabled".to_string(),
+                "loading".to_string(),
+            ],
+        }
+    }
+}

--- a/crates/veneer-adapters/src/lib.rs
+++ b/crates/veneer-adapters/src/lib.rs
@@ -3,12 +3,14 @@
 //! This crate provides the core transformation logic that converts React/Solid JSX
 //! components into static Web Components for documentation previews.
 
+pub mod conventions;
 pub mod generator;
 pub mod inline;
 pub mod react;
 pub mod registry;
 pub mod traits;
 
+pub use conventions::ComponentConventions;
 pub use generator::{generate_controls_panel, generate_web_component};
 pub use inline::{parse_inline_jsx, to_custom_element, InlineJsx, PropValue};
 pub use react::{ComponentStructure, ReactAdapter};

--- a/crates/veneer-adapters/src/react.rs
+++ b/crates/veneer-adapters/src/react.rs
@@ -12,6 +12,7 @@ use oxc_ast::ast::{
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
+use crate::conventions::ComponentConventions;
 use crate::generator::generate_web_component;
 use crate::traits::{FrameworkAdapter, TransformContext, TransformError, TransformedBlock};
 
@@ -66,8 +67,9 @@ impl ComponentStructure {
 }
 
 /// Accumulates extraction results while walking the AST.
-#[derive(Debug, Default)]
-struct ExtractionState {
+#[derive(Debug)]
+struct ExtractionState<'c> {
+    conventions: &'c ComponentConventions,
     variant_lookup: Vec<(String, String)>,
     size_lookup: Vec<(String, String)>,
     base_classes: Option<String>,
@@ -76,14 +78,35 @@ struct ExtractionState {
     observed_attributes: Vec<String>,
 }
 
+impl<'c> ExtractionState<'c> {
+    fn new(conventions: &'c ComponentConventions) -> Self {
+        Self {
+            conventions,
+            variant_lookup: Vec::new(),
+            size_lookup: Vec::new(),
+            base_classes: None,
+            disabled_classes: None,
+            component_name: None,
+            observed_attributes: Vec::new(),
+        }
+    }
+}
+
 /// React/JSX to Web Component adapter.
-#[derive(Debug, Default)]
-pub struct ReactAdapter;
+#[derive(Debug, Clone, Default)]
+pub struct ReactAdapter {
+    conventions: ComponentConventions,
+}
 
 impl ReactAdapter {
-    /// Create a new React adapter.
+    /// Create a new React adapter with default conventions.
     pub fn new() -> Self {
-        Self
+        Self::default()
+    }
+
+    /// Create a new React adapter with custom conventions.
+    pub fn with_conventions(conventions: ComponentConventions) -> Self {
+        Self { conventions }
     }
 
     /// Extract component structure from source code using oxc AST parsing.
@@ -109,7 +132,7 @@ impl ReactAdapter {
             )));
         }
 
-        let mut state = ExtractionState::default();
+        let mut state = ExtractionState::new(&self.conventions);
 
         for stmt in &ret.program.body {
             visit_statement(stmt, &mut state);
@@ -123,9 +146,9 @@ impl ReactAdapter {
         // check for common attribute names used anywhere in the source. This
         // catches components that access props without destructuring (e.g., props.variant).
         if state.observed_attributes.is_empty() {
-            for attr in ["variant", "size", "disabled", "loading"] {
-                if source.contains(attr) {
-                    state.observed_attributes.push(attr.to_string());
+            for attr in &self.conventions.fallback_attributes {
+                if source.contains(attr.as_str()) {
+                    state.observed_attributes.push(attr.clone());
                 }
             }
         }
@@ -190,7 +213,7 @@ impl FrameworkAdapter for ReactAdapter {
 // --- AST walking ---
 
 /// Process a single top-level statement.
-fn visit_statement(stmt: &Statement<'_>, state: &mut ExtractionState) {
+fn visit_statement(stmt: &Statement<'_>, state: &mut ExtractionState<'_>) {
     match stmt {
         Statement::VariableDeclaration(decl) => {
             visit_variable_declaration(decl, state);
@@ -217,7 +240,7 @@ fn visit_statement(stmt: &Statement<'_>, state: &mut ExtractionState) {
 }
 
 /// Process a declaration (shared by top-level statements and named exports).
-fn visit_declaration(decl: &Declaration<'_>, state: &mut ExtractionState) {
+fn visit_declaration(decl: &Declaration<'_>, state: &mut ExtractionState<'_>) {
     match decl {
         Declaration::VariableDeclaration(var_decl) => {
             visit_variable_declaration(var_decl, state);
@@ -233,30 +256,38 @@ fn visit_declaration(decl: &Declaration<'_>, state: &mut ExtractionState) {
 }
 
 /// Extract component name and props from a function declaration.
-fn process_function_decl(func: &oxc_ast::ast::Function<'_>, state: &mut ExtractionState) {
+fn process_function_decl(func: &oxc_ast::ast::Function<'_>, state: &mut ExtractionState<'_>) {
     if let Some(ref id) = func.id {
         let name = id.name.as_str();
         if is_pascal_case(name) && state.component_name.is_none() {
             state.component_name = Some(name.to_string());
         }
-        extract_params_attributes(&func.params, &mut state.observed_attributes);
+        extract_params_attributes(
+            &func.params,
+            &state.conventions.excluded_props,
+            &mut state.observed_attributes,
+        );
     }
 }
 
 /// Extract attributes from a TypeScript interface declaration ending in "Props".
 fn process_interface_decl(
     iface: &oxc_ast::ast::TSInterfaceDeclaration<'_>,
-    state: &mut ExtractionState,
+    state: &mut ExtractionState<'_>,
 ) {
     if iface.id.name.as_str().ends_with("Props") {
-        extract_interface_attributes(iface, &mut state.observed_attributes);
+        extract_interface_attributes(
+            iface,
+            &state.conventions.excluded_props,
+            &mut state.observed_attributes,
+        );
     }
 }
 
 /// Process a variable declaration, looking for known identifiers.
 fn visit_variable_declaration(
     decl: &oxc_ast::ast::VariableDeclaration<'_>,
-    state: &mut ExtractionState,
+    state: &mut ExtractionState<'_>,
 ) {
     for declarator in &decl.declarations {
         let name = match &declarator.id.kind {
@@ -270,39 +301,40 @@ fn visit_variable_declaration(
 
         let init = unwrap_type_expressions(init);
 
-        match name {
-            "variantClasses" => {
-                if let Some(entries) = extract_object_entries(init) {
-                    state.variant_lookup = entries;
-                }
+        if state.conventions.variant_records.iter().any(|v| v == name) {
+            if let Some(entries) = extract_object_entries(init) {
+                state.variant_lookup = entries;
             }
-            "sizeClasses" => {
-                if let Some(entries) = extract_object_entries(init) {
-                    state.size_lookup = entries;
-                }
+        } else if state.conventions.size_records.iter().any(|v| v == name) {
+            if let Some(entries) = extract_object_entries(init) {
+                state.size_lookup = entries;
             }
-            "baseClasses" => {
-                if let Some(value) = extract_string_value(init) {
-                    state.base_classes = Some(normalize_whitespace(&value));
-                }
+        } else if state.conventions.base_class_vars.iter().any(|v| v == name) {
+            if let Some(value) = extract_string_value(init) {
+                state.base_classes = Some(normalize_whitespace(&value));
             }
-            "disabledClasses" | "disabledCls" => {
-                if let Some(value) = extract_string_value(init) {
-                    state.disabled_classes = Some(value);
-                }
+        } else if state
+            .conventions
+            .disabled_class_vars
+            .iter()
+            .any(|v| v == name)
+        {
+            if let Some(value) = extract_string_value(init) {
+                state.disabled_classes = Some(value);
             }
-            _ => {
-                if is_pascal_case(name) && state.component_name.is_none() {
-                    let params = match init {
-                        Expression::ArrowFunctionExpression(arrow) => Some(&arrow.params),
-                        Expression::FunctionExpression(func) => Some(&func.params),
-                        _ => None,
-                    };
-                    if let Some(params) = params {
-                        state.component_name = Some(name.to_string());
-                        extract_params_attributes(params, &mut state.observed_attributes);
-                    }
-                }
+        } else if is_pascal_case(name) && state.component_name.is_none() {
+            let params = match init {
+                Expression::ArrowFunctionExpression(arrow) => Some(&arrow.params),
+                Expression::FunctionExpression(func) => Some(&func.params),
+                _ => None,
+            };
+            if let Some(params) = params {
+                state.component_name = Some(name.to_string());
+                extract_params_attributes(
+                    params,
+                    &state.conventions.excluded_props,
+                    &mut state.observed_attributes,
+                );
             }
         }
     }
@@ -395,6 +427,7 @@ fn extract_string_value(expr: &Expression<'_>) -> Option<String> {
 /// Extract observed attributes from a TSInterfaceDeclaration whose name ends with "Props".
 fn extract_interface_attributes(
     iface: &oxc_ast::ast::TSInterfaceDeclaration<'_>,
+    excluded_props: &[String],
     attrs: &mut Vec<String>,
 ) {
     for sig in &iface.body.body {
@@ -404,7 +437,8 @@ fn extract_interface_attributes(
                 _ => continue,
             };
 
-            if should_include_attribute(name) && !attrs.contains(&name.to_string()) {
+            if should_include_attribute(name, excluded_props) && !attrs.contains(&name.to_string())
+            {
                 attrs.push(name.to_string());
             }
         }
@@ -412,7 +446,11 @@ fn extract_interface_attributes(
 }
 
 /// Extract observed attributes from function parameters (destructured object pattern).
-fn extract_params_attributes(params: &oxc_ast::ast::FormalParameters<'_>, attrs: &mut Vec<String>) {
+fn extract_params_attributes(
+    params: &oxc_ast::ast::FormalParameters<'_>,
+    excluded_props: &[String],
+    attrs: &mut Vec<String>,
+) {
     for param in &params.items {
         if let BindingPatternKind::ObjectPattern(obj_pat) = &param.pattern.kind {
             for prop in &obj_pat.properties {
@@ -421,7 +459,9 @@ fn extract_params_attributes(params: &oxc_ast::ast::FormalParameters<'_>, attrs:
                     _ => continue,
                 };
 
-                if should_include_attribute(name) && !attrs.contains(&name.to_string()) {
+                if should_include_attribute(name, excluded_props)
+                    && !attrs.contains(&name.to_string())
+                {
                     attrs.push(name.to_string());
                 }
             }
@@ -430,9 +470,9 @@ fn extract_params_attributes(params: &oxc_ast::ast::FormalParameters<'_>, attrs:
 }
 
 /// Determine if an attribute name should be included in observed attributes.
-/// Excludes React-specific props that have no Web Component equivalent.
-fn should_include_attribute(name: &str) -> bool {
-    !name.is_empty() && name != "children" && name != "className" && name != "style"
+/// Excludes props listed in the conventions' excluded_props list.
+fn should_include_attribute(name: &str, excluded_props: &[String]) -> bool {
+    !name.is_empty() && !excluded_props.iter().any(|p| p == name)
 }
 
 // --- String helpers ---
@@ -689,5 +729,122 @@ export function Button() {}
             )
         );
         assert_eq!(structure.base_classes, "inline-flex items-center");
+    }
+
+    #[test]
+    fn custom_variant_record_name() {
+        let source = r#"
+const styles = {
+  primary: 'bg-blue-500',
+  danger: 'bg-red-500',
+};
+
+export function Alert() {}
+        "#;
+
+        let conventions = ComponentConventions {
+            variant_records: vec!["styles".to_string()],
+            ..Default::default()
+        };
+        let adapter = ReactAdapter::with_conventions(conventions);
+        let structure = adapter.extract_structure(source).unwrap();
+
+        assert_eq!(structure.variant_lookup.len(), 2);
+        assert_eq!(structure.variant_lookup[0].0, "primary");
+        assert_eq!(structure.variant_lookup[1].0, "danger");
+    }
+
+    #[test]
+    fn custom_size_record_name() {
+        let source = r#"
+const variantClasses = { default: 'bg-primary' };
+const dimensions = {
+  small: 'h-8 px-2',
+  large: 'h-12 px-4',
+};
+
+export function Button() {}
+        "#;
+
+        let conventions = ComponentConventions {
+            size_records: vec!["dimensions".to_string()],
+            ..Default::default()
+        };
+        let adapter = ReactAdapter::with_conventions(conventions);
+        let structure = adapter.extract_structure(source).unwrap();
+
+        assert_eq!(structure.size_lookup.len(), 2);
+        assert_eq!(structure.size_lookup[0].0, "small");
+        assert_eq!(structure.size_lookup[1].0, "large");
+    }
+
+    #[test]
+    fn multiple_variant_record_names() {
+        let source = r#"
+const colorStyles = {
+  red: 'text-red-500',
+  blue: 'text-blue-500',
+};
+
+export function Badge() {}
+        "#;
+
+        let conventions = ComponentConventions {
+            variant_records: vec!["variantClasses".to_string(), "colorStyles".to_string()],
+            ..Default::default()
+        };
+        let adapter = ReactAdapter::with_conventions(conventions);
+        let structure = adapter.extract_structure(source).unwrap();
+
+        assert_eq!(structure.variant_lookup.len(), 2);
+        assert_eq!(structure.variant_lookup[0].0, "red");
+        assert_eq!(structure.variant_lookup[1].0, "blue");
+    }
+
+    #[test]
+    fn custom_excluded_props() {
+        let source = r#"
+const variantClasses = { default: '' };
+
+interface WidgetProps {
+  variant?: string;
+  ref?: any;
+  key?: string;
+  label?: string;
+}
+
+export function Widget({ variant, ref, key, label }: WidgetProps) {}
+        "#;
+
+        let conventions = ComponentConventions {
+            excluded_props: vec!["ref".to_string(), "key".to_string()],
+            ..Default::default()
+        };
+        let adapter = ReactAdapter::with_conventions(conventions);
+        let structure = adapter.extract_structure(source).unwrap();
+
+        assert!(structure
+            .observed_attributes
+            .contains(&"variant".to_string()));
+        assert!(structure.observed_attributes.contains(&"label".to_string()));
+        assert!(!structure.observed_attributes.contains(&"ref".to_string()));
+        assert!(!structure.observed_attributes.contains(&"key".to_string()));
+    }
+
+    #[test]
+    fn errors_when_no_matching_conventions() {
+        let source = r#"
+const myStyles = {
+  primary: 'bg-blue-500',
+};
+
+export function Button() {}
+        "#;
+
+        // Default conventions won't match "myStyles"
+        let adapter = ReactAdapter::new();
+        let result = adapter.extract_structure(source);
+
+        assert!(matches!(result, Err(TransformError::MissingVariants)));
     }
 }


### PR DESCRIPTION
## Summary
- Add `ComponentConventions` struct with serde support for configurable extraction
- `ReactAdapter::with_conventions()` accepts custom variable names for variant/size/base/disabled records
- Configurable excluded props and fallback attributes
- Defaults exactly match previous hardcoded behavior -- 100% backwards compatible
- Foundation for Vue (#16), Solid (#17) adapters and design-system-agnostic extraction

Closes #15

## Test plan
- [x] All 37 existing tests pass without modification (backwards compatible)
- [x] 5 new convention tests pass (custom names, multiple names, custom exclusions)
- [x] `cargo clippy -p veneer-adapters -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)