### PR TITLE
chore: update org references from ezmode-games to rafters-studio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
-repository = "https://github.com/ezmode-games/veneer"
+repository = "https://github.com/rafters-studio/veneer"
 authors = ["Sean Silvius"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Rust-powered component documentation generator with live Web Component previews.
 
 ```bash
 # Install via script
-curl -fsSL https://raw.githubusercontent.com/ezmode-games/veneer/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/rafters-studio/veneer/main/install.sh | bash
 
 # Or build from source
 cargo install --path crates/veneer

--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
-# install.sh: Installer for Veneer (https://github.com/ezmode-games/veneer)
+# install.sh: Installer for Veneer (https://github.com/rafters-studio/veneer)
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/ezmode-games/veneer/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/rafters-studio/veneer/main/install.sh | bash
 #   curl -fsSL ... | bash -s v0.2.0
 #   VENEER_VERSION=v0.2.0 bash install.sh
 
 set -euo pipefail
 
-REPO="ezmode-games/veneer"
+REPO="rafters-studio/veneer"
 INSTALL_DIR="${HOME}/.local/bin"
 BINARY_NAME="veneer"
 


### PR DESCRIPTION
## Summary
- Updates all org references from `ezmode-games` to `rafters-studio` across Cargo.toml files and documentation

## Test plan
- [ ] `cargo build` passes
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)