### PR TITLE
feat: add service design markdown table parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2497,6 +2497,7 @@ dependencies = [
 name = "veneer-service-design"
 version = "0.1.0"
 dependencies = [
+ "regex",
  "serde",
  "serde_json",
  "thiserror",

--- a/crates/veneer-service-design/Cargo.toml
+++ b/crates/veneer-service-design/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
+regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/veneer-service-design/src/lib.rs
+++ b/crates/veneer-service-design/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod error;
 pub mod model;
+pub mod parser;
 
 pub use error::ServiceDesignError;
 pub use model::{
@@ -8,3 +9,4 @@ pub use model::{
     MomentOfTruth, PainPoint, PainPointMatrix, PainTheme, Persona, PersonaOverview, Probe,
     ScoringDimension, ScoringRubric, ServiceDesignArtifact, ValueExchange,
 };
+pub use parser::{ArtifactParser, ArtifactParserRegistry, Frontmatter};

--- a/crates/veneer-service-design/src/parser/blueprint.rs
+++ b/crates/veneer-service-design/src/parser/blueprint.rs
@@ -1,0 +1,272 @@
+use regex::Regex;
+
+use crate::error::ServiceDesignError;
+use crate::model::{Blueprint, BlueprintMeta, BlueprintStep, PainPoint, ServiceDesignArtifact};
+use crate::parser::table::extract_tables;
+use crate::parser::{
+    detect_by_type_or_heading, extract_bold_field, extract_bulleted_list_after,
+    parse_emotional_score, ArtifactParser, Frontmatter,
+};
+
+pub struct BlueprintParser;
+
+impl ArtifactParser for BlueprintParser {
+    fn can_parse(&self, content: &str, frontmatter: &Frontmatter) -> bool {
+        detect_by_type_or_heading(content, frontmatter, "blueprint", "## Service Blueprint")
+    }
+
+    fn parse(
+        &self,
+        content: &str,
+        frontmatter: &Frontmatter,
+    ) -> Result<ServiceDesignArtifact, ServiceDesignError> {
+        let title = frontmatter
+            .get("title")
+            .cloned()
+            .or_else(|| extract_title_from_h1(content))
+            .unwrap_or_default();
+
+        let primary_persona = extract_bold_field(content, "Primary Persona")
+            .ok_or_else(|| ServiceDesignError::MissingField("Primary Persona".into()))?;
+
+        let trigger = extract_bold_field(content, "Trigger")
+            .ok_or_else(|| ServiceDesignError::MissingField("Trigger".into()))?;
+
+        let scope = extract_bold_field(content, "Scope")
+            .ok_or_else(|| ServiceDesignError::MissingField("Scope".into()))?;
+
+        let channels = extract_bold_field(content, "Channels")
+            .map(|c| c.split(',').map(|s| s.trim().to_string()).collect())
+            .unwrap_or_default();
+
+        let secondary_persona = extract_bold_field(content, "Secondary Persona");
+
+        let meta = BlueprintMeta {
+            title,
+            primary_persona,
+            secondary_persona,
+            trigger,
+            scope,
+            channels,
+        };
+
+        let steps = parse_steps(content)?;
+
+        let design_decisions = extract_bulleted_list_after(content, "## Design Decisions");
+        let open_questions = extract_bulleted_list_after(content, "## Open Questions");
+
+        Ok(ServiceDesignArtifact::Blueprint(Blueprint {
+            meta,
+            steps,
+            dependency_map: vec![],
+            design_decisions,
+            open_questions,
+        }))
+    }
+}
+
+fn extract_title_from_h1(content: &str) -> Option<String> {
+    content
+        .lines()
+        .find(|line| line.starts_with("# "))
+        .map(|line| line.trim_start_matches('#').trim().to_string())
+}
+
+fn parse_steps(content: &str) -> Result<Vec<BlueprintStep>, ServiceDesignError> {
+    let step_re =
+        Regex::new(r"(?m)^### Step \d+:\s*(.+)$").map_err(|e| ServiceDesignError::Parse {
+            file: String::new(),
+            message: format!("regex error: {e}"),
+        })?;
+
+    let step_positions: Vec<(usize, String)> = step_re
+        .captures_iter(content)
+        .filter_map(|cap| {
+            let m = cap.get(0)?;
+            Some((m.start(), cap[1].trim().to_string()))
+        })
+        .collect();
+
+    let mut steps = Vec::new();
+
+    for (i, (start, name)) in step_positions.iter().enumerate() {
+        let end = step_positions
+            .get(i + 1)
+            .map(|(pos, _)| *pos)
+            .unwrap_or(content.len());
+
+        let section = &content[*start..end];
+        let step = parse_single_step(section, name)?;
+        steps.push(step);
+    }
+
+    Ok(steps)
+}
+
+fn parse_single_step(section: &str, name: &str) -> Result<BlueprintStep, ServiceDesignError> {
+    let tables = extract_tables(section);
+
+    // Look for the vertical table with Layer | Detail columns
+    let mut evidence = String::new();
+    let mut customer_actions = String::new();
+    let mut frontstage = String::new();
+    let mut backstage = String::new();
+    let mut support_processes = String::new();
+
+    for table in &tables {
+        if table.headers.iter().any(|h| h.to_lowercase() == "layer") {
+            for row in &table.rows {
+                if row.len() >= 2 {
+                    let layer = row[0].to_lowercase();
+                    let detail = &row[1];
+                    if layer.contains("evidence") {
+                        evidence = detail.clone();
+                    } else if layer.contains("customer") {
+                        customer_actions = detail.clone();
+                    } else if layer.contains("frontstage") {
+                        frontstage = detail.clone();
+                    } else if layer.contains("backstage") {
+                        backstage = detail.clone();
+                    } else if layer.contains("support") {
+                        support_processes = detail.clone();
+                    }
+                }
+            }
+        }
+    }
+
+    // Parse pain points
+    let pain_point_items = extract_bulleted_list_after(section, "pain points");
+    let pain_points: Vec<PainPoint> = pain_point_items
+        .into_iter()
+        .map(|item| PainPoint {
+            label: item.clone(),
+            problem: item,
+            workaround: None,
+            cost: None,
+            evidence: None,
+        })
+        .collect();
+
+    // Parse emotional state
+    let (emotional_state, emotional_label) = parse_emotional_state_line(section)?;
+
+    // Parse metrics (optional)
+    let metrics = extract_bulleted_list_after(section, "metrics");
+
+    // Parse moments of truth (optional)
+    let mot_items = extract_bulleted_list_after(section, "moments of truth");
+    let moments_of_truth = mot_items
+        .into_iter()
+        .map(|item| crate::model::MomentOfTruth {
+            moment: item,
+            success_state: String::new(),
+            failure_state: String::new(),
+            why_it_matters: None,
+        })
+        .collect();
+
+    Ok(BlueprintStep {
+        name: name.to_string(),
+        evidence,
+        customer_actions,
+        frontstage,
+        backstage,
+        support_processes,
+        pain_points,
+        emotional_state,
+        emotional_label,
+        metrics,
+        moments_of_truth,
+    })
+}
+
+fn parse_emotional_state_line(
+    section: &str,
+) -> Result<(crate::model::EmotionalScore, String), ServiceDesignError> {
+    for line in section.lines() {
+        let trimmed = line.trim();
+        // Match "**Emotional state:**" or "**Emotional State:**"
+        let lower = trimmed.to_lowercase();
+        if lower.starts_with("**emotional state") || lower.starts_with("**emotional state") {
+            // Extract text after the bold field
+            let after_colon = trimmed
+                .find(":**")
+                .map(|i| &trimmed[i + 3..])
+                .or_else(|| trimmed.find(":** ").map(|i| &trimmed[i + 4..]))
+                .unwrap_or(trimmed);
+            let clean = after_colon.trim();
+            if !clean.is_empty() {
+                return parse_emotional_score(clean);
+            }
+        }
+    }
+
+    // Default to neutral if not found
+    Ok((
+        crate::model::EmotionalScore::new(0).map_err(|e| ServiceDesignError::Parse {
+            file: String::new(),
+            message: format!("default score failed: {e}"),
+        })?,
+        "Neutral".to_string(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn load_fixture() -> String {
+        include_str!("test_fixtures/sample_blueprint.md").to_string()
+    }
+
+    #[test]
+    fn can_parse_by_frontmatter() {
+        let parser = BlueprintParser;
+        let mut fm = HashMap::new();
+        fm.insert("type".to_string(), "blueprint".to_string());
+        assert!(parser.can_parse("", &fm));
+    }
+
+    #[test]
+    fn can_parse_by_heading() {
+        let parser = BlueprintParser;
+        assert!(parser.can_parse("## Service Blueprint\nContent", &HashMap::new()));
+    }
+
+    #[test]
+    fn parse_fixture() {
+        let parser = BlueprintParser;
+        let content = load_fixture();
+        let mut fm = HashMap::new();
+        fm.insert("title".to_string(), "Test Blueprint".to_string());
+        fm.insert("type".to_string(), "blueprint".to_string());
+
+        let result = parser.parse(&content, &fm).unwrap();
+        if let ServiceDesignArtifact::Blueprint(bp) = result {
+            assert_eq!(bp.meta.title, "Test Blueprint");
+            assert_eq!(bp.meta.primary_persona, "Developer");
+            assert_eq!(bp.meta.trigger, "Discovers rafters");
+            assert_eq!(bp.meta.scope, "First run to production");
+            assert_eq!(bp.steps.len(), 2);
+
+            let step1 = &bp.steps[0];
+            assert_eq!(step1.name, "Discovery");
+            assert!(!step1.evidence.is_empty());
+            assert!(!step1.customer_actions.is_empty());
+            assert_eq!(step1.emotional_state.value(), 1);
+            assert_eq!(step1.emotional_label, "Curiosity");
+            assert!(!step1.pain_points.is_empty());
+
+            let step2 = &bp.steps[1];
+            assert_eq!(step2.name, "Installation");
+            assert_eq!(step2.emotional_state.value(), -1);
+
+            assert!(!bp.design_decisions.is_empty());
+            assert!(!bp.open_questions.is_empty());
+        } else {
+            panic!("expected Blueprint variant");
+        }
+    }
+}

--- a/crates/veneer-service-design/src/parser/ecosystem.rs
+++ b/crates/veneer-service-design/src/parser/ecosystem.rs
@@ -1,0 +1,270 @@
+use crate::error::ServiceDesignError;
+use crate::model::{
+    Actor, ActorType, Channel, EcosystemMap, FailureMode, ServiceDesignArtifact, ValueExchange,
+};
+use crate::parser::table::{extract_sections, extract_tables};
+use crate::parser::{detect_by_type_or_heading, find_section_content, ArtifactParser, Frontmatter};
+
+pub struct EcosystemMapParser;
+
+impl ArtifactParser for EcosystemMapParser {
+    fn can_parse(&self, content: &str, frontmatter: &Frontmatter) -> bool {
+        detect_by_type_or_heading(content, frontmatter, "ecosystem", "## Actors")
+    }
+
+    fn parse(
+        &self,
+        content: &str,
+        frontmatter: &Frontmatter,
+    ) -> Result<ServiceDesignArtifact, ServiceDesignError> {
+        let sections = extract_sections(content);
+
+        let title = frontmatter.get("title").cloned().unwrap_or_default();
+
+        let core_service = find_section_content(&sections, "Core Service")
+            .map(|c| c.trim().to_string())
+            .unwrap_or_default();
+
+        let actors = parse_actors(content);
+        let channels = parse_channels(content);
+        let value_exchanges = parse_value_exchanges(content);
+        let failure_modes = parse_failure_modes(content);
+
+        Ok(ServiceDesignArtifact::EcosystemMap(EcosystemMap {
+            title,
+            core_service,
+            actors,
+            channels,
+            value_exchanges,
+            moments_of_truth: vec![],
+            failure_modes,
+        }))
+    }
+}
+
+fn parse_actors(content: &str) -> Vec<Actor> {
+    let sections = extract_sections(content);
+    let mut actors = Vec::new();
+
+    let type_map = [
+        ("Primary", ActorType::Primary),
+        ("Secondary", ActorType::Secondary),
+        ("Tertiary", ActorType::Tertiary),
+        ("Future", ActorType::Future),
+    ];
+
+    for (heading_prefix, actor_type) in &type_map {
+        if let Some(section_content) = find_section_content(&sections, heading_prefix) {
+            let tables = extract_tables(section_content);
+            for table in &tables {
+                let name_idx = find_column_index(&table.headers, "name")
+                    .or_else(|| find_column_index(&table.headers, "actor"));
+                let desc_idx = find_column_index(&table.headers, "description")
+                    .or_else(|| find_column_index(&table.headers, "role"));
+
+                for row in &table.rows {
+                    let name = name_idx
+                        .and_then(|i| row.get(i))
+                        .cloned()
+                        .unwrap_or_default();
+                    let description = desc_idx
+                        .and_then(|i| row.get(i))
+                        .cloned()
+                        .unwrap_or_default();
+
+                    if !name.is_empty() {
+                        actors.push(Actor {
+                            name,
+                            actor_type: actor_type.clone(),
+                            description,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    actors
+}
+
+fn parse_channels(content: &str) -> Vec<Channel> {
+    let sections = extract_sections(content);
+    let mut channels = Vec::new();
+
+    if let Some(section_content) = find_section_content(&sections, "Channels") {
+        let tables = extract_tables(section_content);
+        for table in &tables {
+            let name_idx = find_column_index(&table.headers, "name")
+                .or_else(|| find_column_index(&table.headers, "channel"));
+            let type_idx = find_column_index(&table.headers, "type");
+            let desc_idx = find_column_index(&table.headers, "description");
+
+            for row in &table.rows {
+                let name = name_idx
+                    .and_then(|i| row.get(i))
+                    .cloned()
+                    .unwrap_or_default();
+                let channel_type = type_idx
+                    .and_then(|i| row.get(i))
+                    .cloned()
+                    .unwrap_or_default();
+                let description = desc_idx
+                    .and_then(|i| row.get(i))
+                    .cloned()
+                    .unwrap_or_default();
+
+                if !name.is_empty() {
+                    channels.push(Channel {
+                        name,
+                        channel_type,
+                        description,
+                    });
+                }
+            }
+        }
+    }
+
+    channels
+}
+
+fn parse_value_exchanges(content: &str) -> Vec<ValueExchange> {
+    let sections = extract_sections(content);
+    let mut exchanges = Vec::new();
+
+    if let Some(section_content) = find_section_content(&sections, "Value Exchange") {
+        let tables = extract_tables(section_content);
+        for table in &tables {
+            let actor_idx = find_column_index(&table.headers, "actor");
+            let gives_idx = find_column_index(&table.headers, "gives");
+            let gets_idx = find_column_index(&table.headers, "gets")
+                .or_else(|| find_column_index(&table.headers, "receives"));
+
+            for row in &table.rows {
+                let actor = actor_idx
+                    .and_then(|i| row.get(i))
+                    .cloned()
+                    .unwrap_or_default();
+                let gives = gives_idx
+                    .and_then(|i| row.get(i))
+                    .map(|s| split_items(s))
+                    .unwrap_or_default();
+                let gets = gets_idx
+                    .and_then(|i| row.get(i))
+                    .map(|s| split_items(s))
+                    .unwrap_or_default();
+
+                if !actor.is_empty() {
+                    exchanges.push(ValueExchange { actor, gives, gets });
+                }
+            }
+        }
+    }
+
+    exchanges
+}
+
+fn parse_failure_modes(content: &str) -> Vec<FailureMode> {
+    let sections = extract_sections(content);
+    let mut modes = Vec::new();
+
+    if let Some(section_content) = find_section_content(&sections, "Failure Mode") {
+        let tables = extract_tables(section_content);
+        for table in &tables {
+            let mode_idx = find_column_index(&table.headers, "mode")
+                .or_else(|| find_column_index(&table.headers, "failure"));
+            let impact_idx = find_column_index(&table.headers, "impact");
+            let recovery_idx = find_column_index(&table.headers, "recovery");
+
+            for row in &table.rows {
+                let mode = mode_idx
+                    .and_then(|i| row.get(i))
+                    .cloned()
+                    .unwrap_or_default();
+                let impact = impact_idx
+                    .and_then(|i| row.get(i))
+                    .cloned()
+                    .unwrap_or_default();
+                let recovery = recovery_idx
+                    .and_then(|i| row.get(i))
+                    .cloned()
+                    .unwrap_or_default();
+
+                if !mode.is_empty() {
+                    modes.push(FailureMode {
+                        mode,
+                        impact,
+                        recovery,
+                    });
+                }
+            }
+        }
+    }
+
+    modes
+}
+
+fn find_column_index(headers: &[String], pattern: &str) -> Option<usize> {
+    headers
+        .iter()
+        .position(|h| h.to_lowercase().contains(pattern))
+}
+
+fn split_items(text: &str) -> Vec<String> {
+    text.split([',', ';'])
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn load_fixture() -> String {
+        include_str!("test_fixtures/sample_ecosystem.md").to_string()
+    }
+
+    #[test]
+    fn can_parse_by_frontmatter() {
+        let parser = EcosystemMapParser;
+        let mut fm = HashMap::new();
+        fm.insert("type".to_string(), "ecosystem".to_string());
+        assert!(parser.can_parse("", &fm));
+    }
+
+    #[test]
+    fn can_parse_by_heading() {
+        let parser = EcosystemMapParser;
+        assert!(parser.can_parse("## Actors\n", &HashMap::new()));
+    }
+
+    #[test]
+    fn parse_fixture() {
+        let parser = EcosystemMapParser;
+        let content = load_fixture();
+        let mut fm = HashMap::new();
+        fm.insert("title".to_string(), "Rafters Ecosystem".to_string());
+        fm.insert("type".to_string(), "ecosystem".to_string());
+
+        let result = parser.parse(&content, &fm).unwrap();
+        if let ServiceDesignArtifact::EcosystemMap(em) = result {
+            assert_eq!(em.title, "Rafters Ecosystem");
+            assert!(!em.core_service.is_empty());
+            assert!(!em.actors.is_empty());
+
+            // Check actor types
+            let primary_count = em
+                .actors
+                .iter()
+                .filter(|a| a.actor_type == ActorType::Primary)
+                .count();
+            assert!(primary_count > 0);
+
+            assert!(!em.channels.is_empty());
+            assert!(!em.failure_modes.is_empty());
+        } else {
+            panic!("expected EcosystemMap variant");
+        }
+    }
+}

--- a/crates/veneer-service-design/src/parser/journey.rs
+++ b/crates/veneer-service-design/src/parser/journey.rs
@@ -1,0 +1,211 @@
+use regex::Regex;
+
+use crate::error::ServiceDesignError;
+use crate::model::{JourneyMap, JourneyMeta, JourneyPhase, ServiceDesignArtifact};
+use crate::parser::table::extract_sections;
+use crate::parser::table::extract_tables;
+use crate::parser::{
+    detect_by_type_or_heading, find_section_content, parse_emotional_score, ArtifactParser,
+    Frontmatter,
+};
+
+pub struct JourneyMapParser;
+
+impl ArtifactParser for JourneyMapParser {
+    fn can_parse(&self, content: &str, frontmatter: &Frontmatter) -> bool {
+        if detect_by_type_or_heading(content, frontmatter, "journey-map", "## Journey Phases") {
+            return true;
+        }
+        // Also detect by ### Phase headings
+        content.contains("### Phase")
+    }
+
+    fn parse(
+        &self,
+        content: &str,
+        frontmatter: &Frontmatter,
+    ) -> Result<ServiceDesignArtifact, ServiceDesignError> {
+        let sections = extract_sections(content);
+
+        let title = frontmatter.get("title").cloned().unwrap_or_default();
+
+        let overview_content = find_section_content(&sections, "Overview").unwrap_or("");
+
+        let meta = JourneyMeta {
+            title,
+            persona: extract_overview_field(overview_content, "Persona"),
+            scenario: extract_overview_field(overview_content, "Scenario"),
+            goal: extract_overview_field(overview_content, "Goal"),
+        };
+
+        let phases = parse_phases(content)?;
+
+        Ok(ServiceDesignArtifact::JourneyMap(JourneyMap {
+            meta,
+            phases,
+        }))
+    }
+}
+
+fn extract_overview_field(content: &str, field: &str) -> String {
+    crate::parser::extract_bold_field(content, field).unwrap_or_default()
+}
+
+fn parse_phases(content: &str) -> Result<Vec<JourneyPhase>, ServiceDesignError> {
+    let phase_re =
+        Regex::new(r"(?m)^### Phase \d+:\s*(.+)$").map_err(|e| ServiceDesignError::Parse {
+            file: String::new(),
+            message: format!("regex error: {e}"),
+        })?;
+
+    let phase_positions: Vec<(usize, String)> = phase_re
+        .captures_iter(content)
+        .filter_map(|cap| {
+            let m = cap.get(0)?;
+            Some((m.start(), cap[1].trim().to_string()))
+        })
+        .collect();
+
+    let mut phases = Vec::new();
+
+    for (i, (start, name)) in phase_positions.iter().enumerate() {
+        let end = phase_positions
+            .get(i + 1)
+            .map(|(pos, _)| *pos)
+            .unwrap_or(content.len());
+
+        let section = &content[*start..end];
+        let phase = parse_single_phase(section, name)?;
+        phases.push(phase);
+    }
+
+    Ok(phases)
+}
+
+fn parse_single_phase(section: &str, name: &str) -> Result<JourneyPhase, ServiceDesignError> {
+    let tables = extract_tables(section);
+
+    let mut actions = Vec::new();
+    let mut touchpoints = Vec::new();
+    let mut emotions = String::new();
+    let mut pain_points = Vec::new();
+    let mut opportunities = Vec::new();
+    let mut emotional_score =
+        crate::model::EmotionalScore::new(0).map_err(|e| ServiceDesignError::Parse {
+            file: String::new(),
+            message: format!("default score: {e}"),
+        })?;
+
+    // Look for horizontal table with standard journey map columns
+    for table in &tables {
+        let header_lower: Vec<String> = table.headers.iter().map(|h| h.to_lowercase()).collect();
+
+        for row in &table.rows {
+            for (j, header) in header_lower.iter().enumerate() {
+                if j >= row.len() {
+                    continue;
+                }
+                let cell = &row[j];
+                if cell.is_empty() {
+                    continue;
+                }
+
+                if header.contains("action") {
+                    actions.extend(split_cell_items(cell));
+                } else if header.contains("touchpoint") {
+                    touchpoints.extend(split_cell_items(cell));
+                } else if header.contains("emotional") {
+                    emotions = cell.clone();
+                    if let Ok((score, _)) = parse_emotional_score(cell) {
+                        emotional_score = score;
+                    }
+                } else if header.contains("pain") {
+                    pain_points.extend(split_cell_items(cell));
+                } else if header.contains("opportunit") {
+                    opportunities.extend(split_cell_items(cell));
+                }
+            }
+        }
+    }
+
+    Ok(JourneyPhase {
+        name: name.to_string(),
+        time_range: None,
+        actions,
+        thoughts: vec![],
+        emotions,
+        touchpoints,
+        pain_points,
+        opportunities,
+        emotional_score,
+    })
+}
+
+/// Split a table cell that may contain multiple items separated by commas,
+/// semicolons, or line breaks.
+fn split_cell_items(cell: &str) -> Vec<String> {
+    cell.split([';', '\n'])
+        .flat_map(|part| {
+            if part.contains(',') && !part.contains('(') {
+                part.split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect::<Vec<_>>()
+            } else {
+                vec![part.trim().to_string()]
+            }
+        })
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn load_fixture() -> String {
+        include_str!("test_fixtures/sample_journey.md").to_string()
+    }
+
+    #[test]
+    fn can_parse_by_frontmatter() {
+        let parser = JourneyMapParser;
+        let mut fm = HashMap::new();
+        fm.insert("type".to_string(), "journey-map".to_string());
+        assert!(parser.can_parse("", &fm));
+    }
+
+    #[test]
+    fn can_parse_by_heading() {
+        let parser = JourneyMapParser;
+        assert!(parser.can_parse("## Journey Phases\n", &HashMap::new()));
+    }
+
+    #[test]
+    fn parse_fixture() {
+        let parser = JourneyMapParser;
+        let content = load_fixture();
+        let mut fm = HashMap::new();
+        fm.insert(
+            "title".to_string(),
+            "Developer Onboarding Journey".to_string(),
+        );
+        fm.insert("type".to_string(), "journey-map".to_string());
+
+        let result = parser.parse(&content, &fm).unwrap();
+        if let ServiceDesignArtifact::JourneyMap(jm) = result {
+            assert_eq!(jm.meta.title, "Developer Onboarding Journey");
+            assert!(!jm.meta.persona.is_empty());
+            assert_eq!(jm.phases.len(), 2);
+
+            let phase1 = &jm.phases[0];
+            assert_eq!(phase1.name, "Discovery");
+            assert!(!phase1.actions.is_empty());
+            assert!(!phase1.touchpoints.is_empty());
+            assert!(!phase1.emotions.is_empty());
+        } else {
+            panic!("expected JourneyMap variant");
+        }
+    }
+}

--- a/crates/veneer-service-design/src/parser/mod.rs
+++ b/crates/veneer-service-design/src/parser/mod.rs
@@ -1,0 +1,302 @@
+pub mod table;
+
+mod blueprint;
+mod ecosystem;
+mod journey;
+mod pain_matrix;
+mod persona;
+
+use std::collections::HashMap;
+
+use regex::Regex;
+
+use crate::error::ServiceDesignError;
+use crate::model::{EmotionalScore, ServiceDesignArtifact};
+
+/// Simple frontmatter representation: a map of string key-value pairs.
+/// This avoids coupling to veneer-mdx.
+pub type Frontmatter = HashMap<String, String>;
+
+/// Trait for artifact-specific parsers that convert markdown content into
+/// typed service design artifacts.
+pub trait ArtifactParser: Send + Sync {
+    /// Returns true if this parser can handle the given content/frontmatter.
+    fn can_parse(&self, content: &str, frontmatter: &Frontmatter) -> bool;
+
+    /// Parse the content into a service design artifact.
+    fn parse(
+        &self,
+        content: &str,
+        frontmatter: &Frontmatter,
+    ) -> Result<ServiceDesignArtifact, ServiceDesignError>;
+}
+
+/// Registry of all built-in artifact parsers. Tries each parser in order
+/// and returns the first successful match.
+pub struct ArtifactParserRegistry {
+    parsers: Vec<Box<dyn ArtifactParser>>,
+}
+
+impl ArtifactParserRegistry {
+    /// Create a new registry with all built-in parsers registered.
+    pub fn new() -> Self {
+        let parsers: Vec<Box<dyn ArtifactParser>> = vec![
+            Box::new(blueprint::BlueprintParser),
+            Box::new(journey::JourneyMapParser),
+            Box::new(ecosystem::EcosystemMapParser),
+            Box::new(persona::PersonaParser),
+            Box::new(pain_matrix::PainPointMatrixParser),
+        ];
+        Self { parsers }
+    }
+
+    /// Attempt to parse the given content using registered parsers.
+    /// Returns `Ok(None)` if no parser matches the content.
+    pub fn parse(
+        &self,
+        content: &str,
+        frontmatter: &Frontmatter,
+    ) -> Result<Option<ServiceDesignArtifact>, ServiceDesignError> {
+        for parser in &self.parsers {
+            if parser.can_parse(content, frontmatter) {
+                let artifact = parser.parse(content, frontmatter)?;
+                return Ok(Some(artifact));
+            }
+        }
+        Ok(None)
+    }
+}
+
+impl Default for ArtifactParserRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Parse an emotional score pattern like "Frustrated (-2)" or "Curiosity (+1)"
+/// into an `(EmotionalScore, label)` tuple.
+///
+/// Supports patterns:
+/// - "Label (-2)"
+/// - "Label (+1)"
+/// - "Label (0)"
+/// - "Label (-2). Some extra text"
+pub fn parse_emotional_score(text: &str) -> Result<(EmotionalScore, String), ServiceDesignError> {
+    let re = Regex::new(r"^(.+?)\s*\(([+-]?\d+)\)").map_err(|e| ServiceDesignError::Parse {
+        file: String::new(),
+        message: format!("regex error: {e}"),
+    })?;
+
+    let caps = re
+        .captures(text.trim())
+        .ok_or_else(|| ServiceDesignError::Parse {
+            file: String::new(),
+            message: format!("could not parse emotional score from: {text}"),
+        })?;
+
+    let label = caps[1].trim().to_string();
+    let value: i8 = caps[2].parse().map_err(|_| ServiceDesignError::Parse {
+        file: String::new(),
+        message: format!("invalid score number in: {text}"),
+    })?;
+
+    let score = EmotionalScore::new(value)?;
+    Ok((score, label))
+}
+
+// -- Shared parsing helpers --
+
+/// Extract bold field values like "**Key:** Value" from text content.
+pub(crate) fn extract_bold_field(content: &str, field: &str) -> Option<String> {
+    for line in content.lines() {
+        let trimmed = line.trim();
+        let prefix = format!("**{field}:**");
+        if let Some(rest) = trimmed.strip_prefix(&prefix) {
+            return Some(rest.trim().to_string());
+        }
+        // Also handle the case without trailing colon in the bold
+        let prefix_alt = format!("**{field}**:");
+        if let Some(rest) = trimmed.strip_prefix(&prefix_alt) {
+            return Some(rest.trim().to_string());
+        }
+    }
+    None
+}
+
+/// Extract a bulleted list following a given label line (e.g., "**Pain points:**").
+pub(crate) fn extract_bulleted_list_after(content: &str, label: &str) -> Vec<String> {
+    let mut found = false;
+    let mut items = Vec::new();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if !found {
+            if trimmed.to_lowercase().contains(&label.to_lowercase()) {
+                found = true;
+            }
+            continue;
+        }
+        if let Some(item) = trimmed
+            .strip_prefix("- ")
+            .or_else(|| trimmed.strip_prefix("* "))
+        {
+            items.push(item.trim().to_string());
+        } else if trimmed.is_empty() {
+            // Allow blank lines within a list
+            continue;
+        } else {
+            // Non-list content, stop
+            break;
+        }
+    }
+    items
+}
+
+/// Extract a numbered list from content.
+pub(crate) fn extract_numbered_list(content: &str) -> Vec<String> {
+    let re = Regex::new(r"^\d+\.\s+(.+)$").expect("valid regex");
+    content
+        .lines()
+        .filter_map(|line| re.captures(line.trim()).map(|caps| caps[1].to_string()))
+        .collect()
+}
+
+/// Extract blockquotes from content.
+pub(crate) fn extract_blockquotes(content: &str) -> Vec<String> {
+    let mut quotes = Vec::new();
+    let mut current_quote = Vec::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(quote_text) = trimmed.strip_prefix("> ") {
+            current_quote.push(quote_text.trim().to_string());
+        } else if trimmed == ">" {
+            current_quote.push(String::new());
+        } else if !current_quote.is_empty() {
+            quotes.push(current_quote.join(" ").trim().to_string());
+            current_quote.clear();
+        }
+    }
+    if !current_quote.is_empty() {
+        quotes.push(current_quote.join(" ").trim().to_string());
+    }
+
+    quotes
+}
+
+/// Find a section's content by heading text (case-insensitive prefix match).
+pub(crate) fn find_section_content<'a>(
+    sections: &'a [table::Section],
+    heading: &str,
+) -> Option<&'a str> {
+    sections
+        .iter()
+        .find(|s| {
+            s.heading
+                .to_lowercase()
+                .starts_with(&heading.to_lowercase())
+        })
+        .map(|s| s.content.as_str())
+}
+
+/// Check if frontmatter has a given type value or content contains a heading.
+pub(crate) fn detect_by_type_or_heading(
+    content: &str,
+    frontmatter: &Frontmatter,
+    type_value: &str,
+    heading_pattern: &str,
+) -> bool {
+    if let Some(t) = frontmatter.get("type") {
+        if t == type_value {
+            return true;
+        }
+    }
+    content.contains(heading_pattern)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_emotional_score_negative() {
+        let (score, label) = parse_emotional_score("Frustrated (-2)").unwrap();
+        assert_eq!(score.value(), -2);
+        assert_eq!(label, "Frustrated");
+    }
+
+    #[test]
+    fn parse_emotional_score_positive() {
+        let (score, label) = parse_emotional_score("Curiosity (+1)").unwrap();
+        assert_eq!(score.value(), 1);
+        assert_eq!(label, "Curiosity");
+    }
+
+    #[test]
+    fn parse_emotional_score_zero() {
+        let (score, label) = parse_emotional_score("Skeptical but interested (0)").unwrap();
+        assert_eq!(score.value(), 0);
+        assert_eq!(label, "Skeptical but interested");
+    }
+
+    #[test]
+    fn parse_emotional_score_with_trailing_text() {
+        let (score, label) =
+            parse_emotional_score("Frustrated (-2). Some extra context here").unwrap();
+        assert_eq!(score.value(), -2);
+        assert_eq!(label, "Frustrated");
+    }
+
+    #[test]
+    fn parse_emotional_score_invalid() {
+        assert!(parse_emotional_score("No score here").is_err());
+    }
+
+    #[test]
+    fn parse_emotional_score_out_of_range() {
+        assert!(parse_emotional_score("Extreme (5)").is_err());
+    }
+
+    #[test]
+    fn extract_bold_field_basic() {
+        let content = "**Primary Persona:** Developer\n**Trigger:** User clicks button";
+        assert_eq!(
+            extract_bold_field(content, "Primary Persona"),
+            Some("Developer".to_string())
+        );
+        assert_eq!(
+            extract_bold_field(content, "Trigger"),
+            Some("User clicks button".to_string())
+        );
+        assert_eq!(extract_bold_field(content, "Missing"), None);
+    }
+
+    #[test]
+    fn extract_bulleted_list_basic() {
+        let content = "**Pain points:**\n- First issue\n- Second issue\n\nOther text";
+        let items = extract_bulleted_list_after(content, "pain points");
+        assert_eq!(items, vec!["First issue", "Second issue"]);
+    }
+
+    #[test]
+    fn extract_numbered_list_basic() {
+        let content = "1. First goal\n2. Second goal\n3. Third goal\n";
+        let items = extract_numbered_list(content);
+        assert_eq!(items, vec!["First goal", "Second goal", "Third goal"]);
+    }
+
+    #[test]
+    fn extract_blockquotes_basic() {
+        let content = "> This is a quote\n\n> Another quote";
+        let quotes = extract_blockquotes(content);
+        assert_eq!(quotes, vec!["This is a quote", "Another quote"]);
+    }
+
+    #[test]
+    fn registry_returns_none_for_unknown() {
+        let registry = ArtifactParserRegistry::new();
+        let result = registry
+            .parse("just some random text", &Frontmatter::new())
+            .unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/crates/veneer-service-design/src/parser/pain_matrix.rs
+++ b/crates/veneer-service-design/src/parser/pain_matrix.rs
@@ -1,0 +1,306 @@
+use std::collections::HashMap;
+
+use crate::error::ServiceDesignError;
+use crate::model::{
+    PainPointMatrix, PainTheme, Probe, ScoringDimension, ScoringRubric, ServiceDesignArtifact,
+};
+use crate::parser::table::{extract_sections, extract_tables};
+use crate::parser::{detect_by_type_or_heading, find_section_content, ArtifactParser, Frontmatter};
+
+pub struct PainPointMatrixParser;
+
+impl ArtifactParser for PainPointMatrixParser {
+    fn can_parse(&self, content: &str, frontmatter: &Frontmatter) -> bool {
+        detect_by_type_or_heading(content, frontmatter, "pain-matrix", "## Scoring Rubric")
+            || detect_by_type_or_heading(
+                content,
+                frontmatter,
+                "pain-matrix",
+                "## 1. Scoring Rubric",
+            )
+    }
+
+    fn parse(
+        &self,
+        content: &str,
+        _frontmatter: &Frontmatter,
+    ) -> Result<ServiceDesignArtifact, ServiceDesignError> {
+        let sections = extract_sections(content);
+
+        let rubric = parse_rubric(&sections);
+        let themes = parse_themes(&sections);
+        let ranked_priorities = parse_ranked_priorities(&sections);
+        let disconfirmation_log = parse_disconfirmation_log(&sections);
+        let probe_backlog = parse_probe_backlog(&sections);
+
+        Ok(ServiceDesignArtifact::PainPointMatrix(PainPointMatrix {
+            rubric,
+            themes,
+            ranked_priorities,
+            disconfirmation_log,
+            probe_backlog,
+        }))
+    }
+}
+
+fn parse_rubric(sections: &[crate::parser::table::Section]) -> ScoringRubric {
+    let content = find_section_content(sections, "Scoring Rubric")
+        .or_else(|| find_section_content(sections, "1. Scoring Rubric"))
+        .unwrap_or("");
+
+    let tables = extract_tables(content);
+    let mut dimensions = Vec::new();
+
+    for table in &tables {
+        let name_idx =
+            find_col(&table.headers, "dimension").or_else(|| find_col(&table.headers, "name"));
+        let weight_idx = find_col(&table.headers, "weight");
+        let scale_idx =
+            find_col(&table.headers, "scale").or_else(|| find_col(&table.headers, "max"));
+
+        for row in &table.rows {
+            let name = name_idx
+                .and_then(|i| row.get(i))
+                .cloned()
+                .unwrap_or_default();
+            let weight: f32 = weight_idx
+                .and_then(|i| row.get(i))
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(1.0);
+            let scale_max: u8 = scale_idx
+                .and_then(|i| row.get(i))
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(5);
+
+            if !name.is_empty() {
+                dimensions.push(ScoringDimension {
+                    name,
+                    weight,
+                    scale_max,
+                });
+            }
+        }
+    }
+
+    ScoringRubric { dimensions }
+}
+
+fn parse_themes(sections: &[crate::parser::table::Section]) -> Vec<PainTheme> {
+    let content = find_section_content(sections, "Theme")
+        .or_else(|| find_section_content(sections, "2. Theme"))
+        .unwrap_or("");
+
+    let tables = extract_tables(content);
+    let mut themes = Vec::new();
+
+    for table in &tables {
+        let name_idx =
+            find_col(&table.headers, "theme").or_else(|| find_col(&table.headers, "name"));
+        let composite_idx =
+            find_col(&table.headers, "composite").or_else(|| find_col(&table.headers, "score"));
+        let evidence_idx = find_col(&table.headers, "evidence");
+        let cost_idx = find_col(&table.headers, "cost");
+
+        // Find score dimension columns (anything not name/composite/evidence/cost)
+        let score_cols: Vec<(usize, String)> = table
+            .headers
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| {
+                Some(*i) != name_idx
+                    && Some(*i) != composite_idx
+                    && Some(*i) != evidence_idx
+                    && Some(*i) != cost_idx
+            })
+            .map(|(i, h)| (i, h.clone()))
+            .collect();
+
+        for row in &table.rows {
+            let name = name_idx
+                .and_then(|i| row.get(i))
+                .cloned()
+                .unwrap_or_default();
+            let composite_score: f32 = composite_idx
+                .and_then(|i| row.get(i))
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0.0);
+            let evidence = evidence_idx
+                .and_then(|i| row.get(i))
+                .cloned()
+                .unwrap_or_default();
+            let monthly_cost = cost_idx.and_then(|i| row.get(i)).cloned();
+
+            let mut scores = HashMap::new();
+            for (col_idx, col_name) in &score_cols {
+                if let Some(val) = row.get(*col_idx) {
+                    if let Ok(score) = val.parse::<f32>() {
+                        scores.insert(col_name.clone(), score);
+                    }
+                }
+            }
+
+            if !name.is_empty() {
+                themes.push(PainTheme {
+                    name,
+                    scores,
+                    composite_score,
+                    evidence,
+                    monthly_cost,
+                });
+            }
+        }
+    }
+
+    themes
+}
+
+fn parse_ranked_priorities(sections: &[crate::parser::table::Section]) -> Vec<String> {
+    let content = find_section_content(sections, "Ranked Priorities")
+        .or_else(|| find_section_content(sections, "3. Ranked Priorities"))
+        .unwrap_or("");
+
+    let tables = extract_tables(content);
+    let mut priorities = Vec::new();
+
+    for table in &tables {
+        let name_idx = find_col(&table.headers, "priority")
+            .or_else(|| find_col(&table.headers, "theme"))
+            .or_else(|| find_col(&table.headers, "name"));
+
+        for row in &table.rows {
+            if let Some(name) = name_idx.and_then(|i| row.get(i)) {
+                if !name.is_empty() {
+                    priorities.push(name.clone());
+                }
+            }
+        }
+    }
+
+    // If no table, try numbered list
+    if priorities.is_empty() {
+        priorities = crate::parser::extract_numbered_list(content);
+    }
+
+    priorities
+}
+
+fn parse_disconfirmation_log(sections: &[crate::parser::table::Section]) -> Vec<String> {
+    let content = find_section_content(sections, "Disconfirmation")
+        .or_else(|| find_section_content(sections, "5. Disconfirmation"))
+        .unwrap_or("");
+
+    let tables = extract_tables(content);
+    let mut entries = Vec::new();
+
+    for table in &tables {
+        // Take the first meaningful column content from each row
+        for row in &table.rows {
+            let entry = row
+                .iter()
+                .filter(|c| !c.is_empty())
+                .map(|c| c.as_str())
+                .collect::<Vec<_>>()
+                .join(" - ");
+            if !entry.is_empty() {
+                entries.push(entry);
+            }
+        }
+    }
+
+    entries
+}
+
+fn parse_probe_backlog(sections: &[crate::parser::table::Section]) -> Vec<Probe> {
+    let content = find_section_content(sections, "Probe")
+        .or_else(|| find_section_content(sections, "6. Probe"))
+        .or_else(|| find_section_content(sections, "Experiment Backlog"))
+        .unwrap_or("");
+
+    let tables = extract_tables(content);
+    let mut probes = Vec::new();
+
+    for table in &tables {
+        let question_idx =
+            find_col(&table.headers, "question").or_else(|| find_col(&table.headers, "hypothesis"));
+        let method_idx = find_col(&table.headers, "method");
+        let metric_idx =
+            find_col(&table.headers, "metric").or_else(|| find_col(&table.headers, "success"));
+
+        for row in &table.rows {
+            let question = question_idx
+                .and_then(|i| row.get(i))
+                .cloned()
+                .unwrap_or_default();
+            let method = method_idx
+                .and_then(|i| row.get(i))
+                .cloned()
+                .unwrap_or_default();
+            let success_metric = metric_idx
+                .and_then(|i| row.get(i))
+                .cloned()
+                .unwrap_or_default();
+
+            if !question.is_empty() {
+                probes.push(Probe {
+                    question,
+                    method,
+                    success_metric,
+                });
+            }
+        }
+    }
+
+    probes
+}
+
+fn find_col(headers: &[String], pattern: &str) -> Option<usize> {
+    headers
+        .iter()
+        .position(|h| h.to_lowercase().contains(pattern))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn load_fixture() -> String {
+        include_str!("test_fixtures/sample_pain_matrix.md").to_string()
+    }
+
+    #[test]
+    fn can_parse_by_frontmatter() {
+        let parser = PainPointMatrixParser;
+        let mut fm = HashMap::new();
+        fm.insert("type".to_string(), "pain-matrix".to_string());
+        assert!(parser.can_parse("", &fm));
+    }
+
+    #[test]
+    fn can_parse_by_heading() {
+        let parser = PainPointMatrixParser;
+        assert!(parser.can_parse("## Scoring Rubric\n", &HashMap::new()));
+    }
+
+    #[test]
+    fn parse_fixture() {
+        let parser = PainPointMatrixParser;
+        let content = load_fixture();
+        let mut fm = HashMap::new();
+        fm.insert("type".to_string(), "pain-matrix".to_string());
+
+        let result = parser.parse(&content, &fm).unwrap();
+        if let ServiceDesignArtifact::PainPointMatrix(matrix) = result {
+            assert!(!matrix.rubric.dimensions.is_empty());
+            assert!(!matrix.themes.is_empty());
+
+            let theme = &matrix.themes[0];
+            assert!(!theme.name.is_empty());
+            assert!(theme.composite_score > 0.0);
+
+            assert!(!matrix.ranked_priorities.is_empty());
+            assert!(!matrix.probe_backlog.is_empty());
+        } else {
+            panic!("expected PainPointMatrix variant");
+        }
+    }
+}

--- a/crates/veneer-service-design/src/parser/persona.rs
+++ b/crates/veneer-service-design/src/parser/persona.rs
@@ -1,0 +1,212 @@
+use crate::error::ServiceDesignError;
+use crate::model::{PainPoint, Persona, PersonaOverview, ServiceDesignArtifact};
+use crate::parser::table::extract_sections;
+use crate::parser::{
+    extract_blockquotes, extract_bold_field, extract_numbered_list, find_section_content,
+    ArtifactParser, Frontmatter,
+};
+
+pub struct PersonaParser;
+
+impl ArtifactParser for PersonaParser {
+    fn can_parse(&self, content: &str, frontmatter: &Frontmatter) -> bool {
+        if let Some(t) = frontmatter.get("type") {
+            if t == "persona" {
+                return true;
+            }
+        }
+        // Must have both Overview and Goals headings
+        let has_overview = content.contains("## Overview") || content.contains("## Demographics");
+        let has_goals = content.contains("## Goals");
+        has_overview && has_goals
+    }
+
+    fn parse(
+        &self,
+        content: &str,
+        frontmatter: &Frontmatter,
+    ) -> Result<ServiceDesignArtifact, ServiceDesignError> {
+        let sections = extract_sections(content);
+
+        let overview = parse_overview(content, frontmatter, &sections)?;
+        let background = find_section_content(&sections, "Background")
+            .unwrap_or("")
+            .trim()
+            .to_string();
+
+        // Goals from numbered list
+        let goals_content = find_section_content(&sections, "Goals").unwrap_or("");
+        let goals = extract_numbered_list(goals_content);
+
+        // Pain points / frustrations
+        let frustrations_content = find_section_content(&sections, "Frustration")
+            .or_else(|| find_section_content(&sections, "Pain Point"))
+            .unwrap_or("");
+        let pain_points = parse_pain_points(frustrations_content);
+
+        // Behaviors from bulleted list
+        let behaviors = find_section_content(&sections, "Behavior")
+            .map(extract_bulleted_items)
+            .unwrap_or_default();
+
+        // Quotes from blockquotes
+        let quotes = extract_blockquotes(content);
+
+        Ok(ServiceDesignArtifact::Persona(Persona {
+            overview,
+            background,
+            goals,
+            pain_points,
+            current_tools: vec![],
+            behavioral_patterns: behaviors,
+            technology_expertise: vec![],
+            success_metrics: vec![],
+            quotes,
+        }))
+    }
+}
+
+fn parse_overview(
+    _content: &str,
+    frontmatter: &Frontmatter,
+    sections: &[crate::parser::table::Section],
+) -> Result<PersonaOverview, ServiceDesignError> {
+    let demographics_content = find_section_content(sections, "Demographics")
+        .or_else(|| find_section_content(sections, "Overview"))
+        .unwrap_or("");
+
+    let name = frontmatter
+        .get("title")
+        .cloned()
+        .or_else(|| extract_bold_field(demographics_content, "Name"))
+        .unwrap_or_default();
+
+    let role = extract_bold_field(demographics_content, "Role")
+        .or_else(|| extract_bold_field(demographics_content, "Title"))
+        .unwrap_or_default();
+
+    let age = extract_bold_field(demographics_content, "Age");
+    let location = extract_bold_field(demographics_content, "Location");
+    let experience = extract_bold_field(demographics_content, "Experience");
+
+    Ok(PersonaOverview {
+        name,
+        age,
+        role,
+        location,
+        experience,
+    })
+}
+
+fn parse_pain_points(content: &str) -> Vec<PainPoint> {
+    let items = extract_numbered_list(content);
+    items
+        .into_iter()
+        .map(|item| {
+            // Try to split on "**Label.** description" pattern
+            if let Some((label, problem)) = parse_labeled_item(&item) {
+                PainPoint {
+                    label,
+                    problem,
+                    workaround: None,
+                    cost: None,
+                    evidence: None,
+                }
+            } else {
+                PainPoint {
+                    label: item.clone(),
+                    problem: item,
+                    workaround: None,
+                    cost: None,
+                    evidence: None,
+                }
+            }
+        })
+        .collect()
+}
+
+/// Parse "**Label.** Description text" into (label, description).
+fn parse_labeled_item(text: &str) -> Option<(String, String)> {
+    let trimmed = text.trim();
+    if !trimmed.starts_with("**") {
+        return None;
+    }
+    // Find the closing **
+    let rest = &trimmed[2..];
+    let end = rest.find("**")?;
+    let label = rest[..end].trim_end_matches('.').trim().to_string();
+    let after = rest[end + 2..].trim_start_matches('.').trim().to_string();
+    Some((label, after))
+}
+
+fn extract_bulleted_items(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            trimmed
+                .strip_prefix("- ")
+                .or_else(|| trimmed.strip_prefix("* "))
+                .map(|s| s.trim().to_string())
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn load_fixture() -> String {
+        include_str!("test_fixtures/sample_persona.md").to_string()
+    }
+
+    #[test]
+    fn can_parse_by_frontmatter() {
+        let parser = PersonaParser;
+        let mut fm = HashMap::new();
+        fm.insert("type".to_string(), "persona".to_string());
+        assert!(parser.can_parse("", &fm));
+    }
+
+    #[test]
+    fn can_parse_by_headings() {
+        let parser = PersonaParser;
+        let content = "## Overview\nSome overview\n## Goals\n1. Goal one";
+        assert!(parser.can_parse(content, &HashMap::new()));
+    }
+
+    #[test]
+    fn parse_fixture() {
+        let parser = PersonaParser;
+        let content = load_fixture();
+        let mut fm = HashMap::new();
+        fm.insert("title".to_string(), "Alex Chen".to_string());
+        fm.insert("type".to_string(), "persona".to_string());
+
+        let result = parser.parse(&content, &fm).unwrap();
+        if let ServiceDesignArtifact::Persona(persona) = result {
+            assert_eq!(persona.overview.name, "Alex Chen");
+            assert!(!persona.overview.role.is_empty());
+            assert!(!persona.goals.is_empty());
+            assert!(!persona.pain_points.is_empty());
+            assert!(!persona.behavioral_patterns.is_empty());
+            assert!(!persona.quotes.is_empty());
+        } else {
+            panic!("expected Persona variant");
+        }
+    }
+
+    #[test]
+    fn parse_labeled_item_works() {
+        let (label, desc) =
+            parse_labeled_item("**Config complexity.** Too many files to manage").unwrap();
+        assert_eq!(label, "Config complexity");
+        assert_eq!(desc, "Too many files to manage");
+    }
+
+    #[test]
+    fn parse_labeled_item_none_for_plain() {
+        assert!(parse_labeled_item("Just a plain item").is_none());
+    }
+}

--- a/crates/veneer-service-design/src/parser/table.rs
+++ b/crates/veneer-service-design/src/parser/table.rs
@@ -1,0 +1,239 @@
+/// Represents a parsed markdown table with headers and rows.
+#[derive(Debug, Clone)]
+pub struct MarkdownTable {
+    pub headers: Vec<String>,
+    pub rows: Vec<Vec<String>>,
+}
+
+/// Represents a markdown heading section with its content.
+#[derive(Debug, Clone)]
+pub struct Section {
+    pub heading: String,
+    pub level: u8,
+    pub content: String,
+}
+
+/// Parse a single row of pipe-delimited cells, trimming whitespace.
+fn parse_row(line: &str) -> Vec<String> {
+    let trimmed = line.trim();
+    // Strip leading/trailing pipes
+    let inner = trimmed
+        .strip_prefix('|')
+        .unwrap_or(trimmed)
+        .strip_suffix('|')
+        .unwrap_or(trimmed);
+    inner
+        .split('|')
+        .map(|cell| cell.trim().to_string())
+        .collect()
+}
+
+/// Returns true if the line is a separator row (e.g., |---|---|).
+fn is_separator_row(line: &str) -> bool {
+    let trimmed = line.trim();
+    if !trimmed.contains('|') {
+        return false;
+    }
+    let inner = trimmed
+        .strip_prefix('|')
+        .unwrap_or(trimmed)
+        .strip_suffix('|')
+        .unwrap_or(trimmed);
+    inner.split('|').all(|cell| {
+        let cell = cell.trim();
+        !cell.is_empty() && cell.chars().all(|c| c == '-' || c == ':')
+    })
+}
+
+/// Extract all markdown tables from content. Single-pass parsing.
+pub fn extract_tables(content: &str) -> Vec<MarkdownTable> {
+    let mut tables = Vec::new();
+    let lines: Vec<&str> = content.lines().collect();
+    let mut i = 0;
+
+    while i < lines.len() {
+        // Look for a header row followed by a separator row
+        if i + 1 < lines.len() && lines[i].trim().contains('|') && is_separator_row(lines[i + 1]) {
+            let headers = parse_row(lines[i]);
+            // Skip separator
+            i += 2;
+
+            let mut rows = Vec::new();
+            while i < lines.len() && lines[i].trim().contains('|') && !is_separator_row(lines[i]) {
+                let row = parse_row(lines[i]);
+                rows.push(row);
+                i += 1;
+            }
+
+            tables.push(MarkdownTable { headers, rows });
+        } else {
+            i += 1;
+        }
+    }
+
+    tables
+}
+
+/// Extract all heading-delimited sections from markdown content.
+/// Each heading becomes a section whose content extends until the next
+/// heading of the same or higher (lower number) level.
+pub fn extract_sections(content: &str) -> Vec<Section> {
+    let lines: Vec<&str> = content.lines().collect();
+
+    // First pass: find all heading positions
+    let mut heading_positions: Vec<(usize, u8, String)> = Vec::new();
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if let Some(level) = heading_level(trimmed) {
+            let heading = trimmed.trim_start_matches('#').trim().to_string();
+            heading_positions.push((i, level, heading));
+        }
+    }
+
+    // Second pass: build sections
+    let mut sections = Vec::new();
+    for (idx, (line_idx, level, heading)) in heading_positions.iter().enumerate() {
+        let start = line_idx + 1;
+        let end = heading_positions
+            .get(idx + 1)
+            .map(|(next_line, _, _)| *next_line)
+            .unwrap_or(lines.len());
+
+        let content_str = if start < end {
+            lines[start..end].join("\n")
+        } else {
+            String::new()
+        };
+
+        sections.push(Section {
+            heading: heading.clone(),
+            level: *level,
+            content: content_str,
+        });
+    }
+
+    sections
+}
+
+/// Returns the heading level (1-6) if the line starts with # characters.
+fn heading_level(line: &str) -> Option<u8> {
+    let trimmed = line.trim();
+    if !trimmed.starts_with('#') {
+        return None;
+    }
+    let level = trimmed.chars().take_while(|&c| c == '#').count();
+    if level > 6 {
+        return None;
+    }
+    // Must have a space after the # characters
+    if trimmed.len() > level && trimmed.as_bytes()[level] == b' ' {
+        Some(level as u8)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_simple_table() {
+        let md = "\
+| Name | Age |
+| --- | --- |
+| Alice | 30 |
+| Bob | 25 |
+";
+        let tables = extract_tables(md);
+        assert_eq!(tables.len(), 1);
+        assert_eq!(tables[0].headers, vec!["Name", "Age"]);
+        assert_eq!(tables[0].rows.len(), 2);
+        assert_eq!(tables[0].rows[0], vec!["Alice", "30"]);
+    }
+
+    #[test]
+    fn extract_multiple_tables() {
+        let md = "\
+# Section 1
+
+| A | B |
+|---|---|
+| 1 | 2 |
+
+Some text
+
+| X | Y | Z |
+|---|---|---|
+| a | b | c |
+";
+        let tables = extract_tables(md);
+        assert_eq!(tables.len(), 2);
+        assert_eq!(tables[0].headers.len(), 2);
+        assert_eq!(tables[1].headers.len(), 3);
+    }
+
+    #[test]
+    fn extract_sections_basic() {
+        let md = "\
+# Title
+
+Intro text
+
+## Section A
+
+Content A
+
+## Section B
+
+Content B
+";
+        let sections = extract_sections(md);
+        assert_eq!(sections.len(), 3);
+        assert_eq!(sections[0].heading, "Title");
+        assert_eq!(sections[0].level, 1);
+        assert_eq!(sections[1].heading, "Section A");
+        assert_eq!(sections[1].level, 2);
+        assert!(sections[1].content.contains("Content A"));
+    }
+
+    #[test]
+    fn heading_level_detection() {
+        assert_eq!(heading_level("# Title"), Some(1));
+        assert_eq!(heading_level("## Sub"), Some(2));
+        assert_eq!(heading_level("### Third"), Some(3));
+        assert_eq!(heading_level("Not a heading"), None);
+        assert_eq!(heading_level("#NoSpace"), None);
+    }
+
+    #[test]
+    fn separator_row_detection() {
+        assert!(is_separator_row("| --- | --- |"));
+        assert!(is_separator_row("|---|---|"));
+        assert!(is_separator_row("| :---: | ---: |"));
+        assert!(!is_separator_row("| Name | Age |"));
+        assert!(!is_separator_row("just text"));
+    }
+
+    #[test]
+    fn nested_sections_all_returned() {
+        let md = "\
+## Parent
+
+### Child
+
+Child content
+
+## Sibling
+
+Sibling content
+";
+        let sections = extract_sections(md);
+        assert_eq!(sections.len(), 3);
+        assert_eq!(sections[0].heading, "Parent");
+        assert_eq!(sections[1].heading, "Child");
+        assert!(sections[1].content.contains("Child content"));
+        assert_eq!(sections[2].heading, "Sibling");
+        assert!(sections[2].content.contains("Sibling content"));
+    }
+}

--- a/crates/veneer-service-design/src/parser/test_fixtures/sample_blueprint.md
+++ b/crates/veneer-service-design/src/parser/test_fixtures/sample_blueprint.md
@@ -1,0 +1,53 @@
+## Service Blueprint
+
+**Primary Persona:** Developer
+**Trigger:** Discovers rafters
+**Scope:** First run to production
+**Channels:** CLI, Web
+
+### Step 1: Discovery
+
+| Layer | Detail |
+| --- | --- |
+| Evidence | README, blog posts |
+| Customer Actions | Searches for design token tools |
+| Frontstage | Landing page, docs |
+| Backstage | SEO, content pipeline |
+| Support Processes | Static site hosting |
+
+**Pain points:**
+- Too many competing tools
+- Unclear value proposition
+
+**Emotional state:** Curiosity (+1). Interested but cautious.
+
+**Metrics:**
+- Time on landing page > 2 min
+
+**Moments of truth:**
+- First impression of documentation quality
+
+### Step 2: Installation
+
+| Layer | Detail |
+| --- | --- |
+| Evidence | Install output, first run log |
+| Customer Actions | Runs npx rafters init |
+| Frontstage | CLI prompts and output |
+| Backstage | Package resolution, config generation |
+| Support Processes | npm registry, Node.js |
+
+**Pain points:**
+- Dependency conflicts with existing tools
+
+**Emotional state:** Anxious (-1). Will this break my setup?
+
+## Design Decisions
+
+- CLI-first approach for developer familiarity
+- Zero-config defaults with escape hatches
+
+## Open Questions
+
+- Should we support Yarn PnP out of the box?
+- How to handle monorepo setups?

--- a/crates/veneer-service-design/src/parser/test_fixtures/sample_ecosystem.md
+++ b/crates/veneer-service-design/src/parser/test_fixtures/sample_ecosystem.md
@@ -1,0 +1,46 @@
+## Core Service
+
+Design token pipeline that transforms and distributes tokens across platforms.
+
+## Actors
+
+### Primary
+
+| Name | Description |
+| --- | --- |
+| Frontend Developer | Consumes tokens in React/Vue apps |
+| Designer | Creates and updates tokens in Figma |
+
+### Secondary
+
+| Name | Description |
+| --- | --- |
+| Design System Lead | Governs token naming and structure |
+
+### Tertiary
+
+| Name | Description |
+| --- | --- |
+| CI/CD Pipeline | Automates token builds on merge |
+
+## Channels
+
+| Channel | Type | Description |
+| --- | --- | --- |
+| CLI | Direct | Developer runs commands locally |
+| Figma Plugin | Integration | Syncs tokens from Figma |
+| GitHub Action | Automated | Builds on push to main |
+
+## Value Exchanges
+
+| Actor | Gives | Gets |
+| --- | --- | --- |
+| Designer | Token definitions | Consistent implementations |
+| Developer | Implementation feedback | Ready-to-use tokens |
+
+## Failure Modes
+
+| Mode | Impact | Recovery |
+| --- | --- | --- |
+| Token sync fails silently | Stale values in production | Manual re-sync via CLI |
+| Schema validation error | Build breaks | Fix token file, re-run |

--- a/crates/veneer-service-design/src/parser/test_fixtures/sample_journey.md
+++ b/crates/veneer-service-design/src/parser/test_fixtures/sample_journey.md
@@ -1,0 +1,19 @@
+## Overview
+
+**Persona:** Alex Chen
+**Scenario:** First-time setup of design tokens
+**Goal:** Integrate design tokens into existing React project
+
+## Journey Phases
+
+### Phase 1: Discovery
+
+| Stage | Actions | Touchpoints | Emotional State | Pain Points | Opportunities |
+| --- | --- | --- | --- | --- | --- |
+| Discovery | Searches GitHub, reads blog posts | GitHub, Blog | Curious (+1) | Too many options | Clear comparison page |
+
+### Phase 2: Setup
+
+| Stage | Actions | Touchpoints | Emotional State | Pain Points | Opportunities |
+| --- | --- | --- | --- | --- | --- |
+| Setup | Installs package, runs init | CLI, Docs | Frustrated (-1) | Config file confusion | Better defaults |

--- a/crates/veneer-service-design/src/parser/test_fixtures/sample_pain_matrix.md
+++ b/crates/veneer-service-design/src/parser/test_fixtures/sample_pain_matrix.md
@@ -1,0 +1,35 @@
+## 1. Scoring Rubric
+
+| Dimension | Weight | Scale Max |
+| --- | --- | --- |
+| Frequency | 0.3 | 5 |
+| Severity | 0.3 | 5 |
+| Breadth | 0.2 | 5 |
+| Workaround Cost | 0.2 | 5 |
+
+## 2. Theme Table
+
+| Theme | Frequency | Severity | Breadth | Workaround Cost | Composite | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| Config complexity | 4 | 3 | 5 | 3 | 3.8 | 4 of 5 users mentioned this |
+| Token sync drift | 5 | 4 | 3 | 4 | 4.1 | Observed in 3 codebases |
+
+## 3. Ranked Priorities
+
+| Priority | Theme | Composite |
+| --- | --- | --- |
+| 1 | Token sync drift | 4.1 |
+| 2 | Config complexity | 3.8 |
+
+## 5. Disconfirmation Log
+
+| Assumption | Evidence Against | Status |
+| --- | --- | --- |
+| All devs hate GUIs | 2 of 5 prefer visual tools | Partially disconfirmed |
+
+## 6. Probe / Experiment Backlog
+
+| Question | Method | Success Metric |
+| --- | --- | --- |
+| Does auto-sync reduce drift? | A/B test with 10 teams | Drift incidents drop 50% |
+| Is CLI sufficient for designers? | User interviews | 80% task completion rate |

--- a/crates/veneer-service-design/src/parser/test_fixtures/sample_persona.md
+++ b/crates/veneer-service-design/src/parser/test_fixtures/sample_persona.md
@@ -1,0 +1,33 @@
+## Demographics
+
+**Name:** Alex Chen
+**Age:** 32
+**Role:** Senior Frontend Developer
+**Location:** San Francisco
+**Experience:** 8 years
+
+## Background
+
+Has worked at three startups building design systems from scratch. Frustrated by the gap between design tools and code.
+
+## Goals
+
+1. Reduce time spent on token synchronization
+2. Automate design-to-code pipeline
+3. Maintain consistency across platforms
+
+## Frustrations
+
+1. **Config complexity.** Too many files to manage across tools
+2. **Sync drift.** Tokens in Figma diverge from code without warning
+3. **Documentation gaps.** Hard to find canonical token values
+
+## Behaviors
+
+- Prefers CLI tools over GUIs
+- Reads documentation thoroughly before adopting
+- Contributes to open source on weekends
+
+> "I just want my tokens to work the same in Figma and in code without manual steps."
+
+> "Every design system I have built eventually drifts. The tooling never keeps up."


### PR DESCRIPTION
## Summary
- Five artifact parsers: Blueprint, JourneyMap, EcosystemMap, Persona, PainPointMatrix
- Table and section extraction utilities for single-pass markdown parsing
- Emotional score parser ("Frustrated (-2)" -> EmotionalScore + label)
- ArtifactParserRegistry with automatic type detection via frontmatter or heading patterns
- Test fixtures for all 5 artifact types based on actual vault-2026 formats
- No dependency on veneer-mdx -- uses simple HashMap<String, String> frontmatter

Closes #32

## Test plan
- [x] 34 new parser tests + 12 existing model tests = 46 total in veneer-service-design
- [x] All 143 workspace tests passing
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)