### PR TITLE
feat: veneer extract command with docs generation (#43-#47)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2431,6 +2431,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "veneer-adapters",
+ "veneer-docs",
  "veneer-mdx",
  "veneer-server",
  "veneer-static",
@@ -2450,6 +2451,18 @@ dependencies = [
  "tempfile",
  "thiserror",
  "walkdir",
+]
+
+[[package]]
+name = "veneer-docs"
+version = "0.1.0"
+dependencies = [
+ "regex",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/veneer-server",
     "crates/veneer-static",
     "crates/veneer-service-design",
+    "crates/veneer-docs",
 ]
 
 [workspace.package]
@@ -72,6 +73,7 @@ veneer-registry = { path = "crates/veneer-registry" }
 veneer-server = { path = "crates/veneer-server" }
 veneer-static = { path = "crates/veneer-static" }
 veneer-service-design = { path = "crates/veneer-service-design" }
+veneer-docs = { path = "crates/veneer-docs" }
 
 [profile.release]
 strip = true

--- a/crates/veneer-docs/Cargo.toml
+++ b/crates/veneer-docs/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "veneer-docs"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Documentation extraction and generation for veneer"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+regex = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/veneer-docs/src/cli_parser.rs
+++ b/crates/veneer-docs/src/cli_parser.rs
@@ -1,0 +1,557 @@
+//! CLI help parser -- extracts structured command data from clap v4 --help output.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+/// A parsed CLI command with its flags and subcommands.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ParsedCommand {
+    /// Command name (e.g., "reflect", "kanban create")
+    pub name: String,
+    /// Description from help text
+    pub description: String,
+    /// Flags/options
+    pub flags: Vec<ParsedFlag>,
+    /// Subcommands (recursive)
+    pub subcommands: Vec<ParsedCommand>,
+    /// Usage string
+    pub usage: String,
+    /// Aliases if any
+    pub aliases: Vec<String>,
+}
+
+/// A parsed flag/option from --help output.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ParsedFlag {
+    /// Long name (e.g., "--repo")
+    pub long: Option<String>,
+    /// Short name (e.g., "-v")
+    pub short: Option<String>,
+    /// Value placeholder (e.g., "REPO")
+    pub value_name: Option<String>,
+    /// Description
+    pub description: String,
+    /// Whether the flag is required
+    pub required: bool,
+    /// Default value if any
+    pub default: Option<String>,
+}
+
+/// Errors from CLI help parsing.
+#[derive(Debug, thiserror::Error)]
+pub enum CliParseError {
+    #[error("Binary not found or not executable: {0}")]
+    BinaryNotFound(String),
+
+    #[error("Failed to run --help: {0}")]
+    ExecutionError(String),
+
+    #[error("Non-zero exit from --help: {stderr}")]
+    NonZeroExit { stderr: String },
+}
+
+/// Parse a binary by running --help recursively on all subcommands.
+pub fn parse_cli_help(binary_path: &Path) -> Result<ParsedCommand, CliParseError> {
+    let binary = binary_path
+        .to_str()
+        .ok_or_else(|| CliParseError::BinaryNotFound(binary_path.display().to_string()))?;
+
+    let help_text = run_help(binary, &[])?;
+    let name = binary_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(binary);
+    let mut root = parse_help_text(name, &help_text);
+
+    // Recursively parse subcommands
+    let subcommand_names: Vec<String> = root.subcommands.iter().map(|s| s.name.clone()).collect();
+    let mut parsed_subs = Vec::new();
+
+    for sub_name in &subcommand_names {
+        match run_help(binary, &[sub_name]) {
+            Ok(sub_help) => {
+                let mut sub_cmd = parse_help_text(sub_name, &sub_help);
+
+                // Recurse one more level for nested subcommands (e.g., kanban create)
+                let nested_names: Vec<String> =
+                    sub_cmd.subcommands.iter().map(|s| s.name.clone()).collect();
+                let mut parsed_nested = Vec::new();
+
+                for nested_name in &nested_names {
+                    match run_help(binary, &[sub_name, nested_name]) {
+                        Ok(nested_help) => {
+                            parsed_nested.push(parse_help_text(nested_name, &nested_help));
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "Failed to parse help for {} {}: {}",
+                                sub_name,
+                                nested_name,
+                                e
+                            );
+                        }
+                    }
+                }
+
+                sub_cmd.subcommands = parsed_nested;
+                parsed_subs.push(sub_cmd);
+            }
+            Err(e) => {
+                tracing::warn!("Failed to parse help for {}: {}", sub_name, e);
+            }
+        }
+    }
+
+    root.subcommands = parsed_subs;
+    Ok(root)
+}
+
+/// Run `<binary> [args...] --help` and return stdout.
+fn run_help(binary: &str, args: &[&str]) -> Result<String, CliParseError> {
+    let mut cmd = Command::new(binary);
+    for arg in args {
+        cmd.arg(arg);
+    }
+    cmd.arg("--help");
+
+    let output = cmd
+        .output()
+        .map_err(|e| CliParseError::BinaryNotFound(format!("{}: {}", binary, e)))?;
+
+    // clap --help exits with 0
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(CliParseError::NonZeroExit { stderr });
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Parse a single --help text into a ParsedCommand.
+///
+/// This is public for unit testing with synthetic help text.
+pub fn parse_help_text(name: &str, help_text: &str) -> ParsedCommand {
+    let mut cmd = ParsedCommand {
+        name: name.to_string(),
+        ..Default::default()
+    };
+
+    let mut section = Section::Preamble;
+    let mut description_lines: Vec<String> = Vec::new();
+    let mut current_flag_lines: Vec<String> = Vec::new();
+
+    for line in help_text.lines() {
+        // Detect section transitions
+        if line == "Commands:" {
+            flush_flag(&mut cmd.flags, &mut current_flag_lines);
+            section = Section::Commands;
+            continue;
+        }
+        if line == "Options:" {
+            flush_flag(&mut cmd.flags, &mut current_flag_lines);
+            section = Section::Options;
+            continue;
+        }
+        if line.starts_with("Usage:") {
+            flush_flag(&mut cmd.flags, &mut current_flag_lines);
+            cmd.usage = line.trim_start_matches("Usage:").trim().to_string();
+            section = Section::Usage;
+            continue;
+        }
+        if line == "Arguments:" {
+            flush_flag(&mut cmd.flags, &mut current_flag_lines);
+            section = Section::Arguments;
+            continue;
+        }
+
+        match section {
+            Section::Preamble => {
+                let trimmed = line.trim();
+                if !trimmed.is_empty() {
+                    description_lines.push(trimmed.to_string());
+                }
+            }
+            Section::Usage => {
+                // Multi-line usage -- append if indented
+                let trimmed = line.trim();
+                if !trimmed.is_empty() && line.starts_with(' ') {
+                    cmd.usage.push(' ');
+                    cmd.usage.push_str(trimmed);
+                }
+            }
+            Section::Commands => {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                if let Some((name, desc)) = parse_command_line(trimmed) {
+                    // Skip "help" subcommand
+                    if name != "help" {
+                        cmd.subcommands.push(ParsedCommand {
+                            name,
+                            description: desc,
+                            ..Default::default()
+                        });
+                    }
+                }
+            }
+            Section::Options => {
+                if line.trim().is_empty() {
+                    flush_flag(&mut cmd.flags, &mut current_flag_lines);
+                    continue;
+                }
+                // Continuation line (indented text following a flag)
+                if !line.starts_with("  -")
+                    && !line.starts_with("      --")
+                    && !current_flag_lines.is_empty()
+                {
+                    current_flag_lines.push(line.to_string());
+                } else {
+                    flush_flag(&mut cmd.flags, &mut current_flag_lines);
+                    current_flag_lines.push(line.to_string());
+                }
+            }
+            Section::Arguments => {
+                // Arguments section -- skip for now
+            }
+        }
+    }
+
+    // Flush remaining
+    flush_flag(&mut cmd.flags, &mut current_flag_lines);
+
+    cmd.description = description_lines.join(" ");
+    cmd
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Section {
+    Preamble,
+    Usage,
+    Commands,
+    Options,
+    Arguments,
+}
+
+/// Parse a command line like "  reflect   Store a reflection from a completed session"
+fn parse_command_line(line: &str) -> Option<(String, String)> {
+    let parts: Vec<&str> = line.splitn(2, "  ").collect();
+    if parts.len() == 2 {
+        let name = parts[0].trim().to_string();
+        let desc = parts[1].trim().to_string();
+        if !name.is_empty() {
+            return Some((name, desc));
+        }
+    }
+    // Single word command with no description
+    let name = line.trim();
+    if !name.is_empty() && !name.contains(' ') {
+        return Some((name.to_string(), String::new()));
+    }
+    None
+}
+
+/// Flush accumulated flag lines into a ParsedFlag and push to the vec.
+fn flush_flag(flags: &mut Vec<ParsedFlag>, lines: &mut Vec<String>) {
+    if lines.is_empty() {
+        return;
+    }
+
+    let joined = lines.join(" ");
+    lines.clear();
+
+    if let Some(flag) = parse_flag_line(&joined) {
+        flags.push(flag);
+    }
+}
+
+/// Parse a flag line like "  -v, --verbose      Show informational messages"
+/// or "      --repo <REPO>  Repository name(s), comma-separated"
+fn parse_flag_line(line: &str) -> Option<ParsedFlag> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let mut flag = ParsedFlag::default();
+
+    // Use regex to parse the flag pattern
+    let re = regex::Regex::new(
+        r"^(?:(-\w),\s+)?(--[\w-]+)(?:\s+<([^>]+)>)?\s{2,}(.+?)(?:\s+\[default:\s+([^\]]+)\])?$",
+    )
+    .ok()?;
+
+    if let Some(caps) = re.captures(trimmed) {
+        flag.short = caps.get(1).map(|m| m.as_str().to_string());
+        flag.long = caps.get(2).map(|m| m.as_str().to_string());
+        flag.value_name = caps.get(3).map(|m| m.as_str().to_string());
+        flag.description = caps
+            .get(4)
+            .map(|m| m.as_str().trim().to_string())
+            .unwrap_or_default();
+        flag.default = caps.get(5).map(|m| m.as_str().to_string());
+
+        return Some(flag);
+    }
+
+    // Try simpler pattern: just short flag
+    let re_short =
+        regex::Regex::new(r"^(-\w),\s+(--[\w-]+)\s{2,}(.+?)(?:\s+\[default:\s+([^\]]+)\])?$")
+            .ok()?;
+
+    if let Some(caps) = re_short.captures(trimmed) {
+        flag.short = caps.get(1).map(|m| m.as_str().to_string());
+        flag.long = caps.get(2).map(|m| m.as_str().to_string());
+        flag.description = caps
+            .get(3)
+            .map(|m| m.as_str().trim().to_string())
+            .unwrap_or_default();
+        flag.default = caps.get(4).map(|m| m.as_str().to_string());
+        return Some(flag);
+    }
+
+    // Try pattern without short: "      --flag <VALUE>  description"
+    let re_long = regex::Regex::new(
+        r"^(--[\w-]+)(?:\s+<([^>]+)>)?\s{2,}(.+?)(?:\s+\[default:\s+([^\]]+)\])?$",
+    )
+    .ok()?;
+
+    if let Some(caps) = re_long.captures(trimmed) {
+        flag.long = caps.get(1).map(|m| m.as_str().to_string());
+        flag.value_name = caps.get(2).map(|m| m.as_str().to_string());
+        flag.description = caps
+            .get(3)
+            .map(|m| m.as_str().trim().to_string())
+            .unwrap_or_default();
+        flag.default = caps.get(4).map(|m| m.as_str().to_string());
+        return Some(flag);
+    }
+
+    None
+}
+
+/// Determine if a flag is required by checking the usage string.
+pub fn mark_required_flags(cmd: &mut ParsedCommand) {
+    let usage = cmd.usage.clone();
+    for flag in &mut cmd.flags {
+        if let Some(ref long) = flag.long {
+            // Required flags appear without brackets in the usage string
+            // e.g., "--repo <REPO>" is required, "[--verbose]" is optional
+            let flag_name = long.trim_start_matches('-');
+            let required_pattern = format!("--{}", flag_name);
+            let optional_pattern = format!("[--{}", flag_name);
+
+            if usage.contains(&required_pattern) && !usage.contains(&optional_pattern) {
+                flag.required = true;
+            }
+        }
+    }
+
+    // Recurse into subcommands
+    for sub in &mut cmd.subcommands {
+        mark_required_flags(sub);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_simple_help_output() {
+        let help_text = "\
+Store a reflection from a completed session
+
+Usage: legion reflect [OPTIONS] --repo <REPO>
+
+Options:
+      --repo <REPO>              Repository name
+  -v, --verbose                  Show informational messages
+  -h, --help                     Print help";
+
+        let mut cmd = parse_help_text("reflect", help_text);
+        mark_required_flags(&mut cmd);
+
+        assert_eq!(cmd.name, "reflect");
+        assert_eq!(
+            cmd.description,
+            "Store a reflection from a completed session"
+        );
+        assert_eq!(cmd.usage, "legion reflect [OPTIONS] --repo <REPO>");
+        assert_eq!(cmd.flags.len(), 3);
+
+        // --repo should be required (appears without brackets in usage)
+        let repo = cmd
+            .flags
+            .iter()
+            .find(|f| f.long.as_deref() == Some("--repo"))
+            .unwrap();
+        assert!(repo.required);
+        assert_eq!(repo.value_name.as_deref(), Some("REPO"));
+
+        // --verbose should be optional
+        let verbose = cmd
+            .flags
+            .iter()
+            .find(|f| f.long.as_deref() == Some("--verbose"))
+            .unwrap();
+        assert!(!verbose.required);
+        assert_eq!(verbose.short.as_deref(), Some("-v"));
+    }
+
+    #[test]
+    fn parses_subcommands() {
+        let help_text = "\
+Manage the kanban board
+
+Usage: legion kanban [OPTIONS] <COMMAND>
+
+Commands:
+  create      Create a new card on the kanban board
+  list        List cards for a repo
+  help        Print this message or the help of the given subcommand(s)
+
+Options:
+  -v, --verbose  Show informational messages on stderr (quiet by default)
+  -h, --help     Print help";
+
+        let cmd = parse_help_text("kanban", help_text);
+        assert_eq!(cmd.subcommands.len(), 2); // create, list (skip help)
+        assert_eq!(cmd.subcommands[0].name, "create");
+        assert_eq!(
+            cmd.subcommands[0].description,
+            "Create a new card on the kanban board"
+        );
+        assert_eq!(cmd.subcommands[1].name, "list");
+    }
+
+    #[test]
+    fn parses_flag_with_default() {
+        let help_text = "\
+Start development server
+
+Usage: veneer dev [OPTIONS]
+
+Options:
+  -p, --port <PORT>  Port to listen on [default: 7777]
+  -h, --help         Print help";
+
+        let cmd = parse_help_text("dev", help_text);
+        let port = cmd
+            .flags
+            .iter()
+            .find(|f| f.long.as_deref() == Some("--port"))
+            .unwrap();
+        assert_eq!(port.default.as_deref(), Some("7777"));
+        assert_eq!(port.short.as_deref(), Some("-p"));
+        assert_eq!(port.value_name.as_deref(), Some("PORT"));
+    }
+
+    #[test]
+    fn parses_flag_without_short() {
+        let help_text = "\
+Build
+
+Usage: veneer build [OPTIONS]
+
+Options:
+      --no-minify  Skip minification
+  -h, --help       Print help";
+
+        let cmd = parse_help_text("build", help_text);
+        let no_minify = cmd
+            .flags
+            .iter()
+            .find(|f| f.long.as_deref() == Some("--no-minify"))
+            .unwrap();
+        assert!(no_minify.short.is_none());
+        assert_eq!(no_minify.description, "Skip minification");
+    }
+
+    #[test]
+    fn parses_root_command_with_many_subcommands() {
+        let help_text = "\
+Agent specialization through deliberate practice
+
+Usage: legion [OPTIONS] <COMMAND>
+
+Commands:
+  reflect   Store a reflection from a completed session
+  recall    Recall relevant reflections for the current context
+  consult   Search reflections across all repos for cross-agent consultation
+  post      Post a message to the shared bullpen for other agents
+  boost     Mark a reflection as useful after recalling and applying it
+  signal    Send a structured signal to another agent
+  bullpen   Read the bullpen or check for unread posts
+  kanban    Manage the kanban board
+  watch     Watch for signals and auto-wake sleeping agents
+  serve     Start the web dashboard
+  health    Show current system health and recent trend
+  help      Print this message or the help of the given subcommand(s)
+
+Options:
+  -v, --verbose  Show informational messages on stderr (quiet by default)
+  -h, --help     Print help";
+
+        let cmd = parse_help_text("legion", help_text);
+        assert_eq!(
+            cmd.description,
+            "Agent specialization through deliberate practice"
+        );
+        // 11 subcommands (help excluded)
+        assert_eq!(cmd.subcommands.len(), 11);
+        assert!(cmd.subcommands.iter().all(|s| s.name != "help"));
+    }
+
+    #[test]
+    fn required_detection_from_usage() {
+        let help_text = "\
+Send signal
+
+Usage: legion signal [OPTIONS] --to <TO> --verb <VERB>
+
+Options:
+      --to <TO>        Recipient agent name
+      --verb <VERB>    Signal verb
+      --status <STATUS>  Signal status
+  -h, --help           Print help";
+
+        let mut cmd = parse_help_text("signal", help_text);
+        mark_required_flags(&mut cmd);
+
+        let to = cmd
+            .flags
+            .iter()
+            .find(|f| f.long.as_deref() == Some("--to"))
+            .unwrap();
+        assert!(to.required);
+
+        let verb = cmd
+            .flags
+            .iter()
+            .find(|f| f.long.as_deref() == Some("--verb"))
+            .unwrap();
+        assert!(verb.required);
+
+        let status = cmd
+            .flags
+            .iter()
+            .find(|f| f.long.as_deref() == Some("--status"))
+            .unwrap();
+        assert!(!status.required);
+    }
+
+    #[test]
+    fn empty_description_handled() {
+        let help_text = "\
+Usage: tool cmd
+
+Options:
+  -h, --help  Print help";
+
+        let cmd = parse_help_text("cmd", help_text);
+        assert_eq!(cmd.description, "");
+    }
+}

--- a/crates/veneer-docs/src/lib.rs
+++ b/crates/veneer-docs/src/lib.rs
@@ -1,0 +1,17 @@
+//! Documentation extraction and generation for veneer.
+
+pub mod cli_parser;
+pub mod mdx_reference;
+pub mod sidebar;
+pub mod skeleton;
+
+pub use cli_parser::{
+    mark_required_flags, parse_cli_help, CliParseError, ParsedCommand, ParsedFlag,
+};
+pub use mdx_reference::{
+    generate_command_mdx, generate_reference_pages, GeneratedPage, MdxGenError,
+};
+pub use sidebar::{
+    generate_sidebar, write_sidebar_jsonl, EditorialPage, SidebarError, SidebarNode,
+};
+pub use skeleton::{generate_default_skeletons, generate_skeleton, PageTemplate, SkeletonError};

--- a/crates/veneer-docs/src/mdx_reference.rs
+++ b/crates/veneer-docs/src/mdx_reference.rs
@@ -1,0 +1,367 @@
+//! MDX reference page generation from parsed CLI command data.
+
+use std::fmt::Write;
+use std::path::{Path, PathBuf};
+
+use crate::cli_parser::{ParsedCommand, ParsedFlag};
+
+/// A generated MDX reference page.
+#[derive(Debug, Clone)]
+pub struct GeneratedPage {
+    /// Path to the generated MDX file.
+    pub path: PathBuf,
+    /// Page title (e.g., "kanban create").
+    pub title: String,
+    /// Raw command name (e.g., "create").
+    pub command_name: String,
+}
+
+/// Errors from MDX generation.
+#[derive(Debug, thiserror::Error)]
+pub enum MdxGenError {
+    #[error("Failed to write MDX file: {0}")]
+    WriteError(String),
+
+    #[error("IO error: {0}")]
+    IoError(String),
+}
+
+impl From<std::io::Error> for MdxGenError {
+    fn from(e: std::io::Error) -> Self {
+        MdxGenError::IoError(e.to_string())
+    }
+}
+
+/// Returns true if the flag is -h/--help and should be skipped from the table.
+fn is_help_flag(flag: &ParsedFlag) -> bool {
+    flag.long.as_deref() == Some("--help") || flag.short.as_deref() == Some("-h")
+}
+
+/// Filter flags to exclude -h/--help.
+fn visible_flags(flags: &[ParsedFlag]) -> Vec<&ParsedFlag> {
+    flags.iter().filter(|f| !is_help_flag(f)).collect()
+}
+
+/// Generate an MDX reference page for a single command.
+///
+/// If `parent_name` is provided, the title becomes "parent_name command_name".
+pub fn generate_command_mdx(
+    command: &ParsedCommand,
+    parent_name: Option<&str>,
+    layout: Option<&str>,
+) -> String {
+    let mut out = String::new();
+
+    let title = match parent_name {
+        Some(parent) => format!("{} {}", parent, command.name),
+        None => command.name.clone(),
+    };
+
+    // Frontmatter
+    writeln!(out, "---").unwrap();
+    if let Some(layout_path) = layout {
+        writeln!(out, "layout: {}", layout_path).unwrap();
+    }
+    writeln!(out, "title: \"{}\"", title).unwrap();
+    writeln!(
+        out,
+        "description: \"{}\"",
+        command.description.replace('"', "\\\"")
+    )
+    .unwrap();
+    writeln!(out, "---").unwrap();
+    writeln!(out).unwrap();
+
+    // Overview editorial slot
+    writeln!(out, "{{/* veneer:overview */}}").unwrap();
+    writeln!(out).unwrap();
+
+    // Usage section
+    writeln!(out, "## Usage").unwrap();
+    writeln!(out).unwrap();
+    writeln!(out, "```bash").unwrap();
+    writeln!(out, "{}", command.usage).unwrap();
+    writeln!(out, "```").unwrap();
+    writeln!(out).unwrap();
+
+    // Flags table (only if there are visible flags)
+    let flags = visible_flags(&command.flags);
+    if !flags.is_empty() {
+        writeln!(out, "## Flags").unwrap();
+        writeln!(out).unwrap();
+        writeln!(out, "| Flag | Short | Required | Default | Description |").unwrap();
+        writeln!(out, "| --- | --- | --- | --- | --- |").unwrap();
+
+        for flag in &flags {
+            let long = flag.long.as_deref().unwrap_or("");
+            let short = flag.short.as_deref().unwrap_or("");
+            let required = if flag.required { "Yes" } else { "No" };
+            let default = flag.default.as_deref().unwrap_or("");
+            let desc = &flag.description;
+
+            writeln!(
+                out,
+                "| `{}` | `{}` | {} | {} | {} |",
+                long, short, required, default, desc
+            )
+            .unwrap();
+        }
+        writeln!(out).unwrap();
+    }
+
+    // Remaining editorial slots
+    writeln!(out, "{{/* veneer:when-to-use */}}").unwrap();
+    writeln!(out).unwrap();
+    writeln!(out, "{{/* veneer:examples */}}").unwrap();
+    writeln!(out).unwrap();
+    writeln!(out, "{{/* veneer:gotchas */}}").unwrap();
+
+    out
+}
+
+/// Generate MDX reference pages for a command tree.
+///
+/// Creates one MDX file per command in `output_dir/reference/`.
+/// Subcommands go in subdirectories: `reference/kanban/create.mdx`.
+pub fn generate_reference_pages(
+    root: &ParsedCommand,
+    output_dir: &Path,
+    layout: Option<&str>,
+) -> Result<Vec<GeneratedPage>, MdxGenError> {
+    let reference_dir = output_dir.join("reference");
+    let mut pages = Vec::new();
+
+    // Generate page for root command
+    let root_path = reference_dir.join(format!("{}.mdx", root.name));
+    let root_mdx = generate_command_mdx(root, None, layout);
+    write_mdx_file(&root_path, &root_mdx)?;
+    pages.push(GeneratedPage {
+        path: root_path,
+        title: root.name.clone(),
+        command_name: root.name.clone(),
+    });
+
+    // Generate pages for subcommands
+    for sub in &root.subcommands {
+        let sub_dir = reference_dir.join(&root.name);
+        let sub_path = sub_dir.join(format!("{}.mdx", sub.name));
+        let sub_mdx = generate_command_mdx(sub, Some(&root.name), layout);
+        write_mdx_file(&sub_path, &sub_mdx)?;
+        pages.push(GeneratedPage {
+            path: sub_path,
+            title: format!("{} {}", root.name, sub.name),
+            command_name: sub.name.clone(),
+        });
+
+        // Nested subcommands (e.g., kanban create)
+        for nested in &sub.subcommands {
+            let nested_dir = sub_dir.join(&sub.name);
+            let nested_path = nested_dir.join(format!("{}.mdx", nested.name));
+            let parent_title = format!("{} {}", root.name, sub.name);
+            let nested_mdx = generate_command_mdx(nested, Some(&parent_title), layout);
+            write_mdx_file(&nested_path, &nested_mdx)?;
+            pages.push(GeneratedPage {
+                path: nested_path,
+                title: format!("{} {} {}", root.name, sub.name, nested.name),
+                command_name: nested.name.clone(),
+            });
+        }
+    }
+
+    Ok(pages)
+}
+
+/// Write MDX content to a file, creating parent directories as needed.
+fn write_mdx_file(path: &Path, content: &str) -> Result<(), MdxGenError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            MdxGenError::WriteError(format!(
+                "Failed to create directory {}: {}",
+                parent.display(),
+                e
+            ))
+        })?;
+    }
+    std::fs::write(path, content)
+        .map_err(|e| MdxGenError::WriteError(format!("Failed to write {}: {}", path.display(), e)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_command() -> ParsedCommand {
+        ParsedCommand {
+            name: "reflect".to_string(),
+            description: "Store a reflection from a completed session".to_string(),
+            usage: "legion reflect [OPTIONS] --repo <REPO>".to_string(),
+            flags: vec![
+                ParsedFlag {
+                    long: Some("--repo".to_string()),
+                    short: None,
+                    value_name: Some("REPO".to_string()),
+                    description: "Repository name".to_string(),
+                    required: true,
+                    default: None,
+                },
+                ParsedFlag {
+                    long: Some("--verbose".to_string()),
+                    short: Some("-v".to_string()),
+                    value_name: None,
+                    description: "Show informational messages".to_string(),
+                    required: false,
+                    default: None,
+                },
+                ParsedFlag {
+                    long: Some("--help".to_string()),
+                    short: Some("-h".to_string()),
+                    value_name: None,
+                    description: "Print help".to_string(),
+                    required: false,
+                    default: None,
+                },
+            ],
+            subcommands: Vec::new(),
+            aliases: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn generates_valid_frontmatter() {
+        let cmd = make_command();
+        let mdx = generate_command_mdx(&cmd, None, None);
+
+        assert!(mdx.starts_with("---\n"));
+        assert!(mdx.contains("title: \"reflect\""));
+        assert!(mdx.contains("description: \"Store a reflection from a completed session\""));
+        // Frontmatter closes
+        let second_dash = mdx[4..].find("---\n").unwrap();
+        assert!(second_dash > 0);
+    }
+
+    #[test]
+    fn generates_flag_table_with_correct_columns() {
+        let cmd = make_command();
+        let mdx = generate_command_mdx(&cmd, None, None);
+
+        assert!(mdx.contains("## Flags"));
+        assert!(mdx.contains("| Flag | Short | Required | Default | Description |"));
+        assert!(mdx.contains("| `--repo` | `` | Yes |  | Repository name |"));
+        assert!(mdx.contains("| `--verbose` | `-v` | No |  | Show informational messages |"));
+    }
+
+    #[test]
+    fn includes_editorial_slots() {
+        let cmd = make_command();
+        let mdx = generate_command_mdx(&cmd, None, None);
+
+        assert!(mdx.contains("{/* veneer:overview */}"));
+        assert!(mdx.contains("{/* veneer:when-to-use */}"));
+        assert!(mdx.contains("{/* veneer:examples */}"));
+        assert!(mdx.contains("{/* veneer:gotchas */}"));
+    }
+
+    #[test]
+    fn nested_subcommand_uses_parent_name_in_title() {
+        let cmd = ParsedCommand {
+            name: "create".to_string(),
+            description: "Create a new card".to_string(),
+            usage: "legion kanban create [OPTIONS]".to_string(),
+            flags: vec![ParsedFlag {
+                long: Some("--help".to_string()),
+                short: Some("-h".to_string()),
+                value_name: None,
+                description: "Print help".to_string(),
+                required: false,
+                default: None,
+            }],
+            subcommands: Vec::new(),
+            aliases: Vec::new(),
+        };
+
+        let mdx = generate_command_mdx(&cmd, Some("kanban"), None);
+        assert!(mdx.contains("title: \"kanban create\""));
+    }
+
+    #[test]
+    fn skips_help_flag_from_table() {
+        let cmd = make_command();
+        let mdx = generate_command_mdx(&cmd, None, None);
+
+        // Should not contain --help in the table rows
+        assert!(!mdx.contains("| `--help`"));
+        // But should still have the flags section (other flags exist)
+        assert!(mdx.contains("## Flags"));
+    }
+
+    #[test]
+    fn no_flags_section_when_only_help() {
+        let cmd = ParsedCommand {
+            name: "health".to_string(),
+            description: "Show system health".to_string(),
+            usage: "legion health".to_string(),
+            flags: vec![ParsedFlag {
+                long: Some("--help".to_string()),
+                short: Some("-h".to_string()),
+                value_name: None,
+                description: "Print help".to_string(),
+                required: false,
+                default: None,
+            }],
+            subcommands: Vec::new(),
+            aliases: Vec::new(),
+        };
+
+        let mdx = generate_command_mdx(&cmd, None, None);
+        assert!(!mdx.contains("## Flags"));
+    }
+
+    #[test]
+    fn generates_correct_file_paths_for_nested_commands() {
+        let root = ParsedCommand {
+            name: "legion".to_string(),
+            description: "Agent tool".to_string(),
+            usage: "legion <COMMAND>".to_string(),
+            flags: vec![],
+            subcommands: vec![ParsedCommand {
+                name: "kanban".to_string(),
+                description: "Manage kanban".to_string(),
+                usage: "legion kanban <COMMAND>".to_string(),
+                flags: vec![],
+                subcommands: vec![ParsedCommand {
+                    name: "create".to_string(),
+                    description: "Create a card".to_string(),
+                    usage: "legion kanban create [OPTIONS]".to_string(),
+                    flags: vec![],
+                    subcommands: Vec::new(),
+                    aliases: Vec::new(),
+                }],
+                aliases: Vec::new(),
+            }],
+            aliases: Vec::new(),
+        };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let pages = generate_reference_pages(&root, tmp.path(), None).unwrap();
+
+        assert_eq!(pages.len(), 3);
+
+        // Root
+        assert_eq!(pages[0].path, tmp.path().join("reference/legion.mdx"));
+        assert_eq!(pages[0].title, "legion");
+
+        // Subcommand
+        assert_eq!(
+            pages[1].path,
+            tmp.path().join("reference/legion/kanban.mdx")
+        );
+        assert_eq!(pages[1].title, "legion kanban");
+
+        // Nested subcommand
+        assert_eq!(
+            pages[2].path,
+            tmp.path().join("reference/legion/kanban/create.mdx")
+        );
+        assert_eq!(pages[2].title, "legion kanban create");
+    }
+}

--- a/crates/veneer-docs/src/mdx_reference.rs
+++ b/crates/veneer-docs/src/mdx_reference.rs
@@ -93,15 +93,23 @@ pub fn generate_command_mdx(
         writeln!(out, "| --- | --- | --- | --- | --- |").unwrap();
 
         for flag in &flags {
-            let long = flag.long.as_deref().unwrap_or("");
-            let short = flag.short.as_deref().unwrap_or("");
+            let long = flag
+                .long
+                .as_deref()
+                .map(|l| format!("`{}`", l))
+                .unwrap_or_else(|| "-".to_string());
+            let short = flag
+                .short
+                .as_deref()
+                .map(|s| format!("`{}`", s))
+                .unwrap_or_else(|| "-".to_string());
             let required = if flag.required { "Yes" } else { "No" };
-            let default = flag.default.as_deref().unwrap_or("");
+            let default = flag.default.as_deref().unwrap_or("-");
             let desc = &flag.description;
 
             writeln!(
                 out,
-                "| `{}` | `{}` | {} | {} | {} |",
+                "| {} | {} | {} | {} | {} |",
                 long, short, required, default, desc
             )
             .unwrap();
@@ -246,8 +254,8 @@ mod tests {
 
         assert!(mdx.contains("## Flags"));
         assert!(mdx.contains("| Flag | Short | Required | Default | Description |"));
-        assert!(mdx.contains("| `--repo` | `` | Yes |  | Repository name |"));
-        assert!(mdx.contains("| `--verbose` | `-v` | No |  | Show informational messages |"));
+        assert!(mdx.contains("| `--repo` | - | Yes | - | Repository name |"));
+        assert!(mdx.contains("| `--verbose` | `-v` | No | - | Show informational messages |"));
     }
 
     #[test]

--- a/crates/veneer-docs/src/sidebar.rs
+++ b/crates/veneer-docs/src/sidebar.rs
@@ -1,0 +1,358 @@
+//! Sidebar generation -- produces a sidebar.jsonl from parsed CLI commands and editorial pages.
+
+use std::io::Write;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::cli_parser::ParsedCommand;
+
+/// A node in the sidebar tree.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SidebarNode {
+    /// Display title
+    pub title: String,
+    /// URL path (e.g., "/docs/getting-started/install")
+    pub path: Option<String>,
+    /// Icon identifier (optional)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+    /// Child nodes for groups
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub children: Vec<SidebarNode>,
+    /// Sort order within the parent group
+    pub order: u32,
+    /// Logical group name (e.g., "getting-started", "commands")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<String>,
+}
+
+/// An editorial (hand-written) page to include in the sidebar.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EditorialPage {
+    /// Display title
+    pub title: String,
+    /// URL path
+    pub path: String,
+    /// Section slug (e.g., "getting-started", "concepts")
+    pub section: String,
+    /// Sort order within the section
+    pub order: u32,
+}
+
+/// Errors from sidebar generation and writing.
+#[derive(Debug, thiserror::Error)]
+pub enum SidebarError {
+    #[error("Failed to write sidebar file: {0}")]
+    WriteError(#[from] std::io::Error),
+}
+
+/// Generate sidebar nodes from parsed CLI commands and editorial pages.
+///
+/// Editorial pages come first, grouped by section. Commands follow, grouped
+/// by category: commands with subcommands become their own group, flat commands
+/// collect under a "Commands" group.
+pub fn generate_sidebar(
+    commands: &ParsedCommand,
+    editorial_pages: &[EditorialPage],
+) -> Vec<SidebarNode> {
+    let mut nodes: Vec<SidebarNode> = Vec::new();
+    let mut group_order: u32 = 0;
+
+    // -- Editorial pages first, grouped by section --
+    let mut sections: Vec<String> = Vec::new();
+    for page in editorial_pages {
+        if !sections.contains(&page.section) {
+            sections.push(page.section.clone());
+        }
+    }
+
+    for section in &sections {
+        let mut children: Vec<EditorialPage> = editorial_pages
+            .iter()
+            .filter(|p| &p.section == section)
+            .cloned()
+            .collect();
+        children.sort_by_key(|p| p.order);
+
+        let child_nodes: Vec<SidebarNode> = children
+            .iter()
+            .map(|p| SidebarNode {
+                title: p.title.clone(),
+                path: Some(p.path.clone()),
+                icon: None,
+                children: Vec::new(),
+                order: p.order,
+                group: Some(section.clone()),
+            })
+            .collect();
+
+        nodes.push(SidebarNode {
+            title: section_to_title(section),
+            path: None,
+            icon: None,
+            children: child_nodes,
+            order: group_order,
+            group: Some(section.clone()),
+        });
+        group_order += 1;
+    }
+
+    // -- Commands from parsed CLI output --
+    // Split subcommands into two buckets:
+    //   1. Commands that have their own subcommands -> become a group
+    //   2. Flat commands (no subcommands) -> collect under "Commands"
+
+    let mut flat_commands: Vec<SidebarNode> = Vec::new();
+
+    for sub in &commands.subcommands {
+        // Skip -h/--help flags -- we do this during node construction, not here.
+        if sub.subcommands.is_empty() {
+            flat_commands.push(command_to_node(sub, flat_commands.len() as u32));
+        } else {
+            // Command with subcommands becomes its own group
+            let children: Vec<SidebarNode> = sub
+                .subcommands
+                .iter()
+                .enumerate()
+                .map(|(i, nested)| command_to_node(nested, i as u32))
+                .collect();
+
+            nodes.push(SidebarNode {
+                title: capitalize(&sub.name),
+                path: Some(format!("/docs/cli/{}", sub.name)),
+                icon: None,
+                children,
+                order: group_order,
+                group: Some("commands".to_string()),
+            });
+            group_order += 1;
+        }
+    }
+
+    if !flat_commands.is_empty() {
+        nodes.push(SidebarNode {
+            title: "Commands".to_string(),
+            path: None,
+            icon: None,
+            children: flat_commands,
+            order: group_order,
+            group: Some("commands".to_string()),
+        });
+    }
+
+    nodes
+}
+
+/// Write sidebar nodes as JSONL (one JSON object per line).
+pub fn write_sidebar_jsonl(nodes: &[SidebarNode], output: &Path) -> Result<(), SidebarError> {
+    let mut file = std::fs::File::create(output)?;
+    for node in nodes {
+        let json = serde_json::to_string(node)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        writeln!(file, "{}", json)?;
+    }
+    Ok(())
+}
+
+/// Convert a ParsedCommand to a leaf SidebarNode.
+fn command_to_node(cmd: &ParsedCommand, order: u32) -> SidebarNode {
+    SidebarNode {
+        title: capitalize(&cmd.name),
+        path: Some(format!("/docs/cli/{}", cmd.name)),
+        icon: None,
+        children: Vec::new(),
+        order,
+        group: Some("commands".to_string()),
+    }
+}
+
+/// Convert a section slug like "getting-started" to "Getting Started".
+fn section_to_title(slug: &str) -> String {
+    slug.split('-')
+        .map(capitalize)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Capitalize the first character of a string.
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_uppercase().to_string() + chars.as_str(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli_parser::ParsedCommand;
+
+    fn make_root_with_subcommands() -> ParsedCommand {
+        ParsedCommand {
+            name: "mytool".to_string(),
+            description: "My tool".to_string(),
+            subcommands: vec![
+                ParsedCommand {
+                    name: "build".to_string(),
+                    description: "Build the project".to_string(),
+                    ..Default::default()
+                },
+                ParsedCommand {
+                    name: "serve".to_string(),
+                    description: "Start server".to_string(),
+                    ..Default::default()
+                },
+                ParsedCommand {
+                    name: "kanban".to_string(),
+                    description: "Manage kanban board".to_string(),
+                    subcommands: vec![
+                        ParsedCommand {
+                            name: "create".to_string(),
+                            description: "Create a card".to_string(),
+                            ..Default::default()
+                        },
+                        ParsedCommand {
+                            name: "list".to_string(),
+                            description: "List cards".to_string(),
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }
+    }
+
+    fn make_editorial_pages() -> Vec<EditorialPage> {
+        vec![
+            EditorialPage {
+                title: "Installation".to_string(),
+                path: "/docs/getting-started/install".to_string(),
+                section: "getting-started".to_string(),
+                order: 0,
+            },
+            EditorialPage {
+                title: "Quick Start".to_string(),
+                path: "/docs/getting-started/quickstart".to_string(),
+                section: "getting-started".to_string(),
+                order: 1,
+            },
+            EditorialPage {
+                title: "Architecture".to_string(),
+                path: "/docs/concepts/architecture".to_string(),
+                section: "concepts".to_string(),
+                order: 0,
+            },
+        ]
+    }
+
+    #[test]
+    fn generates_grouped_sidebar_from_commands() {
+        let root = make_root_with_subcommands();
+        let sidebar = generate_sidebar(&root, &[]);
+
+        // kanban has subcommands -> its own group
+        // build, serve are flat -> under "Commands" group
+        assert_eq!(sidebar.len(), 2); // "Kanban" group + "Commands" group
+
+        let kanban_group = sidebar.iter().find(|n| n.title == "Kanban").unwrap();
+        assert_eq!(kanban_group.children.len(), 2);
+        assert_eq!(kanban_group.children[0].title, "Create");
+        assert_eq!(kanban_group.children[1].title, "List");
+
+        let commands_group = sidebar.iter().find(|n| n.title == "Commands").unwrap();
+        assert_eq!(commands_group.children.len(), 2);
+        assert_eq!(commands_group.children[0].title, "Build");
+        assert_eq!(commands_group.children[1].title, "Serve");
+    }
+
+    #[test]
+    fn editorial_pages_come_first() {
+        let root = make_root_with_subcommands();
+        let pages = make_editorial_pages();
+        let sidebar = generate_sidebar(&root, &pages);
+
+        // Editorial sections come first
+        assert_eq!(sidebar[0].title, "Getting Started");
+        assert_eq!(sidebar[0].children.len(), 2);
+        assert_eq!(sidebar[0].children[0].title, "Installation");
+        assert_eq!(sidebar[0].children[1].title, "Quick Start");
+
+        assert_eq!(sidebar[1].title, "Concepts");
+        assert_eq!(sidebar[1].children.len(), 1);
+        assert_eq!(sidebar[1].children[0].title, "Architecture");
+
+        // Commands come after editorial
+        assert!(sidebar[0].order < sidebar[2].order);
+        assert!(sidebar[1].order < sidebar[2].order);
+    }
+
+    #[test]
+    fn writes_valid_jsonl() {
+        let root = make_root_with_subcommands();
+        let pages = make_editorial_pages();
+        let sidebar = generate_sidebar(&root, &pages);
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sidebar.jsonl");
+        write_sidebar_jsonl(&sidebar, &path).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+
+        // Each line should be valid JSON
+        assert!(!lines.is_empty());
+        for line in &lines {
+            let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
+            assert!(parsed.is_object());
+        }
+    }
+
+    #[test]
+    fn subcommands_become_nested_groups() {
+        let root = ParsedCommand {
+            name: "tool".to_string(),
+            subcommands: vec![ParsedCommand {
+                name: "db".to_string(),
+                description: "Database operations".to_string(),
+                subcommands: vec![
+                    ParsedCommand {
+                        name: "migrate".to_string(),
+                        description: "Run migrations".to_string(),
+                        ..Default::default()
+                    },
+                    ParsedCommand {
+                        name: "seed".to_string(),
+                        description: "Seed data".to_string(),
+                        ..Default::default()
+                    },
+                    ParsedCommand {
+                        name: "reset".to_string(),
+                        description: "Reset database".to_string(),
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let sidebar = generate_sidebar(&root, &[]);
+        assert_eq!(sidebar.len(), 1);
+        assert_eq!(sidebar[0].title, "Db");
+        assert_eq!(sidebar[0].children.len(), 3);
+        assert_eq!(sidebar[0].children[0].title, "Migrate");
+        assert_eq!(sidebar[0].children[1].title, "Seed");
+        assert_eq!(sidebar[0].children[2].title, "Reset");
+    }
+
+    #[test]
+    fn empty_input_produces_empty_output() {
+        let root = ParsedCommand::default();
+        let sidebar = generate_sidebar(&root, &[]);
+        assert!(sidebar.is_empty());
+    }
+}

--- a/crates/veneer-docs/src/skeleton.rs
+++ b/crates/veneer-docs/src/skeleton.rs
@@ -1,0 +1,272 @@
+//! Skeleton page generator -- creates editorial MDX templates with slot markers.
+
+use std::fs;
+use std::path::Path;
+
+use crate::mdx_reference::GeneratedPage;
+
+/// Page template type.
+#[derive(Debug, Clone)]
+pub enum PageTemplate {
+    GettingStarted,
+    Concept { topic: String },
+    Architecture,
+}
+
+/// Errors from skeleton generation.
+#[derive(Debug, thiserror::Error)]
+pub enum SkeletonError {
+    #[error("Failed to write skeleton page: {0}")]
+    WriteError(#[from] std::io::Error),
+}
+
+/// Generate a skeleton MDX page.
+pub fn generate_skeleton(
+    template: &PageTemplate,
+    project_name: &str,
+    layout: Option<&str>,
+) -> String {
+    let layout_line = layout
+        .map(|l| format!("layout: {}\n", l))
+        .unwrap_or_default();
+
+    match template {
+        PageTemplate::GettingStarted => format!(
+            "\
+---
+{layout_line}title: Getting Started
+description: Install and start using {project_name}.
+order: 0
+---
+
+{{/* veneer:prerequisites */}}
+
+## Install
+
+{{/* veneer:install */}}
+
+## First Use
+
+{{/* veneer:first-use */}}
+
+## Next Steps
+
+{{/* veneer:next-steps */}}
+"
+        ),
+        PageTemplate::Architecture => format!(
+            "\
+---
+{layout_line}title: Architecture
+description: How {project_name} is structured and how the pieces fit together.
+order: 1
+---
+
+{{/* veneer:overview */}}
+
+## Project Structure
+
+{{/* veneer:project-structure */}}
+
+## Data Flow
+
+{{/* veneer:data-flow */}}
+
+## Key Design Decisions
+
+{{/* veneer:design-decisions */}}
+"
+        ),
+        PageTemplate::Concept { topic } => {
+            let title = capitalize(topic);
+            format!(
+                "\
+---
+{layout_line}title: {title}
+description: How {topic} works in {project_name}.
+order: 10
+---
+
+{{/* veneer:overview */}}
+
+## How It Works
+
+{{/* veneer:how-it-works */}}
+
+## Key Concepts
+
+{{/* veneer:key-concepts */}}
+
+## Related
+
+{{/* veneer:related */}}
+"
+            )
+        }
+    }
+}
+
+/// Generate default skeleton pages for a project.
+///
+/// Creates getting-started, architecture, and concept pages based on
+/// detected command groups. Never overwrites existing files.
+pub fn generate_default_skeletons(
+    project_name: &str,
+    command_groups: &[String],
+    output_dir: &Path,
+    layout: Option<&str>,
+) -> Result<Vec<GeneratedPage>, SkeletonError> {
+    let mut pages = Vec::new();
+
+    // Getting started
+    let gs_path = output_dir.join("getting-started.mdx");
+    if write_if_new(
+        &gs_path,
+        &generate_skeleton(&PageTemplate::GettingStarted, project_name, layout),
+    )? {
+        pages.push(GeneratedPage {
+            path: gs_path,
+            title: "Getting Started".to_string(),
+            command_name: String::new(),
+        });
+    }
+
+    // Architecture
+    let arch_path = output_dir.join("architecture.mdx");
+    if write_if_new(
+        &arch_path,
+        &generate_skeleton(&PageTemplate::Architecture, project_name, layout),
+    )? {
+        pages.push(GeneratedPage {
+            path: arch_path,
+            title: "Architecture".to_string(),
+            command_name: String::new(),
+        });
+    }
+
+    // Concept pages from command groups
+    let concepts_dir = output_dir.join("concepts");
+    for group in command_groups {
+        let concept_path = concepts_dir.join(format!("{}.mdx", group));
+        let template = PageTemplate::Concept {
+            topic: group.clone(),
+        };
+        if write_if_new(
+            &concept_path,
+            &generate_skeleton(&template, project_name, layout),
+        )? {
+            pages.push(GeneratedPage {
+                path: concept_path,
+                title: capitalize(group),
+                command_name: String::new(),
+            });
+        }
+    }
+
+    Ok(pages)
+}
+
+/// Write content to path only if the file does not already exist.
+/// Returns true if the file was written, false if skipped.
+fn write_if_new(path: &Path, content: &str) -> Result<bool, SkeletonError> {
+    if path.exists() {
+        tracing::warn!("Skipping existing file: {}", path.display());
+        return Ok(false);
+    }
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    fs::write(path, content)?;
+    Ok(true)
+}
+
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn generates_getting_started_with_project_name() {
+        let mdx = generate_skeleton(&PageTemplate::GettingStarted, "legion", None);
+        assert!(mdx.contains("Install and start using legion"));
+        assert!(mdx.contains("{/* veneer:install */}"));
+        assert!(mdx.contains("{/* veneer:prerequisites */}"));
+        assert!(mdx.contains("{/* veneer:first-use */}"));
+        assert!(mdx.contains("{/* veneer:next-steps */}"));
+    }
+
+    #[test]
+    fn generates_architecture_with_project_name() {
+        let mdx = generate_skeleton(&PageTemplate::Architecture, "legion", None);
+        assert!(mdx.contains("title: Architecture"));
+        assert!(mdx.contains("How legion is structured"));
+        assert!(mdx.contains("{/* veneer:project-structure */}"));
+    }
+
+    #[test]
+    fn generates_concept_page_with_topic() {
+        let mdx = generate_skeleton(
+            &PageTemplate::Concept {
+                topic: "reflections".into(),
+            },
+            "legion",
+            None,
+        );
+        assert!(mdx.contains("title: Reflections"));
+        assert!(mdx.contains("How reflections works in legion"));
+        assert!(mdx.contains("{/* veneer:how-it-works */}"));
+    }
+
+    #[test]
+    fn does_not_overwrite_existing() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("getting-started.mdx");
+
+        // Write initial content
+        fs::write(&path, "existing content").unwrap();
+
+        // Try to generate -- should skip
+        let pages = generate_default_skeletons("test", &[], dir.path(), None).unwrap();
+
+        // getting-started was skipped, architecture was created
+        assert_eq!(pages.len(), 1);
+        assert_eq!(pages[0].title, "Architecture");
+
+        // Original content preserved
+        let content = fs::read_to_string(&path).unwrap();
+        assert_eq!(content, "existing content");
+    }
+
+    #[test]
+    fn generates_concept_pages_from_groups() {
+        let dir = tempdir().unwrap();
+        let groups = vec!["memory".to_string(), "communication".to_string()];
+        let pages = generate_default_skeletons("legion", &groups, dir.path(), None).unwrap();
+
+        // getting-started + architecture + 2 concepts = 4
+        assert_eq!(pages.len(), 4);
+        assert!(dir.path().join("concepts/memory.mdx").exists());
+        assert!(dir.path().join("concepts/communication.mdx").exists());
+    }
+
+    #[test]
+    fn frontmatter_is_valid_yaml() {
+        let mdx = generate_skeleton(&PageTemplate::GettingStarted, "legion", None);
+        assert!(mdx.starts_with("---\n"));
+        let end = mdx.find("\n---\n").unwrap();
+        let yaml = &mdx[4..end];
+        assert!(yaml.contains("title:"));
+        assert!(yaml.contains("description:"));
+        assert!(yaml.contains("order:"));
+    }
+}

--- a/crates/veneer-docs/src/skeleton.rs
+++ b/crates/veneer-docs/src/skeleton.rs
@@ -83,7 +83,7 @@ order: 1
                 "\
 ---
 {layout_line}title: {title}
-description: How {topic} works in {project_name}.
+description: Learn about {topic} in {project_name}.
 order: 10
 ---
 
@@ -223,7 +223,7 @@ mod tests {
             None,
         );
         assert!(mdx.contains("title: Reflections"));
-        assert!(mdx.contains("How reflections works in legion"));
+        assert!(mdx.contains("Learn about reflections in legion"));
         assert!(mdx.contains("{/* veneer:how-it-works */}"));
     }
 

--- a/crates/veneer/Cargo.toml
+++ b/crates/veneer/Cargo.toml
@@ -23,6 +23,7 @@ veneer-mdx = { workspace = true }
 veneer-adapters = { workspace = true }
 veneer-server = { workspace = true }
 veneer-static = { workspace = true }
+veneer-docs = { workspace = true }
 open = { workspace = true }
 tower-http = { workspace = true }
 axum = { workspace = true }

--- a/crates/veneer/src/commands/extract.rs
+++ b/crates/veneer/src/commands/extract.rs
@@ -1,0 +1,111 @@
+//! Extract documentation from a target project.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Args;
+use veneer_docs::{
+    generate_default_skeletons, generate_reference_pages, generate_sidebar, mark_required_flags,
+    parse_cli_help, write_sidebar_jsonl, EditorialPage,
+};
+
+#[derive(Args)]
+pub struct ExtractArgs {
+    /// Path to the target project to extract docs from
+    #[arg(short, long)]
+    project: PathBuf,
+
+    /// Output directory for generated MDX files
+    #[arg(short, long, default_value = "docs")]
+    output: PathBuf,
+
+    /// Path to the project binary for --help extraction
+    #[arg(short, long)]
+    binary: Option<PathBuf>,
+
+    /// Layout path to inject into MDX frontmatter (e.g., "../../layouts/Docs.astro")
+    #[arg(short, long)]
+    layout: Option<String>,
+}
+
+pub async fn run(args: ExtractArgs) -> Result<()> {
+    let project_name = args
+        .project
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("project")
+        .to_string();
+
+    if !args.project.exists() {
+        anyhow::bail!("Project path does not exist: {}", args.project.display());
+    }
+
+    tracing::info!("Extracting docs from {}", args.project.display());
+
+    // Phase 1: Parse CLI help if binary is provided
+    let mut reference_pages = Vec::new();
+    let mut command_groups: Vec<String> = Vec::new();
+
+    if let Some(ref binary_path) = args.binary {
+        if !binary_path.exists() {
+            anyhow::bail!("Binary not found: {}", binary_path.display());
+        }
+
+        tracing::info!("Parsing CLI help from {}", binary_path.display());
+
+        let mut root_cmd = parse_cli_help(binary_path)?;
+        mark_required_flags(&mut root_cmd);
+
+        // Extract command groups (subcommands that have their own subcommands)
+        for sub in &root_cmd.subcommands {
+            if !sub.subcommands.is_empty() {
+                command_groups.push(sub.name.clone());
+            }
+        }
+
+        // Phase 2: Generate reference MDX pages
+        let ref_dir = args.output.clone();
+        let pages = generate_reference_pages(&root_cmd, &ref_dir, args.layout.as_deref())?;
+        tracing::info!("Generated {} reference pages", pages.len());
+        reference_pages = pages;
+
+        // Phase 3: Generate sidebar JSONL
+        let editorial_pages: Vec<EditorialPage> = vec![
+            EditorialPage {
+                title: "Getting Started".to_string(),
+                path: "/getting-started".to_string(),
+                section: "getting-started".to_string(),
+                order: 0,
+            },
+            EditorialPage {
+                title: "Architecture".to_string(),
+                path: "/architecture".to_string(),
+                section: "concepts".to_string(),
+                order: 1,
+            },
+        ];
+
+        let sidebar = generate_sidebar(&root_cmd, &editorial_pages);
+        let sidebar_path = args.output.join("sidebar.jsonl");
+        write_sidebar_jsonl(&sidebar, &sidebar_path)?;
+        tracing::info!("Generated sidebar at {}", sidebar_path.display());
+    }
+
+    // Phase 4: Generate skeleton editorial pages
+    let skeletons = generate_default_skeletons(
+        &project_name,
+        &command_groups,
+        &args.output,
+        args.layout.as_deref(),
+    )?;
+    tracing::info!("Generated {} skeleton pages", skeletons.len());
+
+    let total = reference_pages.len() + skeletons.len();
+    tracing::info!(
+        "Extraction complete: {} total pages in {}",
+        total,
+        args.output.display()
+    );
+
+    Ok(())
+}

--- a/crates/veneer/src/commands/mod.rs
+++ b/crates/veneer/src/commands/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod build;
 pub mod dev;
+pub mod extract;
 pub mod init;
 pub mod serve;
 pub mod watch;

--- a/crates/veneer/src/main.rs
+++ b/crates/veneer/src/main.rs
@@ -69,6 +69,9 @@ enum Commands {
 
     /// Watch for file changes and rebuild (no HTTP server)
     Watch(commands::watch::WatchArgs),
+
+    /// Extract documentation from a target project
+    Extract(commands::extract::ExtractArgs),
 }
 
 #[tokio::main]
@@ -101,6 +104,9 @@ async fn main() -> Result<()> {
         }
         Commands::Watch(args) => {
             commands::watch::run(args, cli.config).await?;
+        }
+        Commands::Extract(args) => {
+            commands::extract::run(args).await?;
         }
     }
 


### PR DESCRIPTION
## Summary

- New `veneer-docs` crate with 4 modules: CLI help parser, sidebar JSONL generator, reference MDX generator, skeleton page generator
- New `veneer extract` command generates complete documentation from CLI binaries
- `--layout` flag injects layout frontmatter for Astro/shingle integration
- Tested against legion: 63 pages (56 reference + 7 editorial) in under 1 second
- 25 tests, clippy clean, fmt clean

## Test plan

- [x] 25 unit tests across all 4 modules
- [x] Integration test: `veneer extract --project legion --binary legion` produces correct output
- [x] Generated MDX builds successfully in runlegion.dev shingle site (66 pages)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

Resolves #43, #44, #45, #46, #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)