### PR TITLE
feat: add --layout flag to veneer extract (#49)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # OS
 .DS_Store
 Thumbs.db
+.playwright-mcp/

--- a/crates/veneer-docs/src/mdx_reference.rs
+++ b/crates/veneer-docs/src/mdx_reference.rs
@@ -45,7 +45,11 @@ fn visible_flags(flags: &[ParsedFlag]) -> Vec<&ParsedFlag> {
 /// Generate an MDX reference page for a single command.
 ///
 /// If `parent_name` is provided, the title becomes "parent_name command_name".
-pub fn generate_command_mdx(command: &ParsedCommand, parent_name: Option<&str>) -> String {
+pub fn generate_command_mdx(
+    command: &ParsedCommand,
+    parent_name: Option<&str>,
+    layout: Option<&str>,
+) -> String {
     let mut out = String::new();
 
     let title = match parent_name {
@@ -55,6 +59,9 @@ pub fn generate_command_mdx(command: &ParsedCommand, parent_name: Option<&str>) 
 
     // Frontmatter
     writeln!(out, "---").unwrap();
+    if let Some(layout_path) = layout {
+        writeln!(out, "layout: {}", layout_path).unwrap();
+    }
     writeln!(out, "title: \"{}\"", title).unwrap();
     writeln!(
         out,
@@ -86,15 +93,23 @@ pub fn generate_command_mdx(command: &ParsedCommand, parent_name: Option<&str>) 
         writeln!(out, "| --- | --- | --- | --- | --- |").unwrap();
 
         for flag in &flags {
-            let long = flag.long.as_deref().unwrap_or("");
-            let short = flag.short.as_deref().unwrap_or("");
+            let long = flag
+                .long
+                .as_deref()
+                .map(|l| format!("`{}`", l))
+                .unwrap_or_else(|| "-".to_string());
+            let short = flag
+                .short
+                .as_deref()
+                .map(|s| format!("`{}`", s))
+                .unwrap_or_else(|| "-".to_string());
             let required = if flag.required { "Yes" } else { "No" };
-            let default = flag.default.as_deref().unwrap_or("");
+            let default = flag.default.as_deref().unwrap_or("-");
             let desc = &flag.description;
 
             writeln!(
                 out,
-                "| `{}` | `{}` | {} | {} | {} |",
+                "| {} | {} | {} | {} | {} |",
                 long, short, required, default, desc
             )
             .unwrap();
@@ -119,13 +134,14 @@ pub fn generate_command_mdx(command: &ParsedCommand, parent_name: Option<&str>) 
 pub fn generate_reference_pages(
     root: &ParsedCommand,
     output_dir: &Path,
+    layout: Option<&str>,
 ) -> Result<Vec<GeneratedPage>, MdxGenError> {
     let reference_dir = output_dir.join("reference");
     let mut pages = Vec::new();
 
     // Generate page for root command
     let root_path = reference_dir.join(format!("{}.mdx", root.name));
-    let root_mdx = generate_command_mdx(root, None);
+    let root_mdx = generate_command_mdx(root, None, layout);
     write_mdx_file(&root_path, &root_mdx)?;
     pages.push(GeneratedPage {
         path: root_path,
@@ -137,7 +153,7 @@ pub fn generate_reference_pages(
     for sub in &root.subcommands {
         let sub_dir = reference_dir.join(&root.name);
         let sub_path = sub_dir.join(format!("{}.mdx", sub.name));
-        let sub_mdx = generate_command_mdx(sub, Some(&root.name));
+        let sub_mdx = generate_command_mdx(sub, Some(&root.name), layout);
         write_mdx_file(&sub_path, &sub_mdx)?;
         pages.push(GeneratedPage {
             path: sub_path,
@@ -150,7 +166,7 @@ pub fn generate_reference_pages(
             let nested_dir = sub_dir.join(&sub.name);
             let nested_path = nested_dir.join(format!("{}.mdx", nested.name));
             let parent_title = format!("{} {}", root.name, sub.name);
-            let nested_mdx = generate_command_mdx(nested, Some(&parent_title));
+            let nested_mdx = generate_command_mdx(nested, Some(&parent_title), layout);
             write_mdx_file(&nested_path, &nested_mdx)?;
             pages.push(GeneratedPage {
                 path: nested_path,
@@ -221,7 +237,7 @@ mod tests {
     #[test]
     fn generates_valid_frontmatter() {
         let cmd = make_command();
-        let mdx = generate_command_mdx(&cmd, None);
+        let mdx = generate_command_mdx(&cmd, None, None);
 
         assert!(mdx.starts_with("---\n"));
         assert!(mdx.contains("title: \"reflect\""));
@@ -234,18 +250,18 @@ mod tests {
     #[test]
     fn generates_flag_table_with_correct_columns() {
         let cmd = make_command();
-        let mdx = generate_command_mdx(&cmd, None);
+        let mdx = generate_command_mdx(&cmd, None, None);
 
         assert!(mdx.contains("## Flags"));
         assert!(mdx.contains("| Flag | Short | Required | Default | Description |"));
-        assert!(mdx.contains("| `--repo` | `` | Yes |  | Repository name |"));
-        assert!(mdx.contains("| `--verbose` | `-v` | No |  | Show informational messages |"));
+        assert!(mdx.contains("| `--repo` | - | Yes | - | Repository name |"));
+        assert!(mdx.contains("| `--verbose` | `-v` | No | - | Show informational messages |"));
     }
 
     #[test]
     fn includes_editorial_slots() {
         let cmd = make_command();
-        let mdx = generate_command_mdx(&cmd, None);
+        let mdx = generate_command_mdx(&cmd, None, None);
 
         assert!(mdx.contains("{/* veneer:overview */}"));
         assert!(mdx.contains("{/* veneer:when-to-use */}"));
@@ -271,14 +287,14 @@ mod tests {
             aliases: Vec::new(),
         };
 
-        let mdx = generate_command_mdx(&cmd, Some("kanban"));
+        let mdx = generate_command_mdx(&cmd, Some("kanban"), None);
         assert!(mdx.contains("title: \"kanban create\""));
     }
 
     #[test]
     fn skips_help_flag_from_table() {
         let cmd = make_command();
-        let mdx = generate_command_mdx(&cmd, None);
+        let mdx = generate_command_mdx(&cmd, None, None);
 
         // Should not contain --help in the table rows
         assert!(!mdx.contains("| `--help`"));
@@ -304,7 +320,7 @@ mod tests {
             aliases: Vec::new(),
         };
 
-        let mdx = generate_command_mdx(&cmd, None);
+        let mdx = generate_command_mdx(&cmd, None, None);
         assert!(!mdx.contains("## Flags"));
     }
 
@@ -334,7 +350,7 @@ mod tests {
         };
 
         let tmp = tempfile::tempdir().unwrap();
-        let pages = generate_reference_pages(&root, tmp.path()).unwrap();
+        let pages = generate_reference_pages(&root, tmp.path(), None).unwrap();
 
         assert_eq!(pages.len(), 3);
 

--- a/crates/veneer-docs/src/skeleton.rs
+++ b/crates/veneer-docs/src/skeleton.rs
@@ -21,12 +21,20 @@ pub enum SkeletonError {
 }
 
 /// Generate a skeleton MDX page.
-pub fn generate_skeleton(template: &PageTemplate, project_name: &str) -> String {
+pub fn generate_skeleton(
+    template: &PageTemplate,
+    project_name: &str,
+    layout: Option<&str>,
+) -> String {
+    let layout_line = layout
+        .map(|l| format!("layout: {}\n", l))
+        .unwrap_or_default();
+
     match template {
         PageTemplate::GettingStarted => format!(
             "\
 ---
-title: Getting Started
+{layout_line}title: Getting Started
 description: Install and start using {project_name}.
 order: 0
 ---
@@ -49,7 +57,7 @@ order: 0
         PageTemplate::Architecture => format!(
             "\
 ---
-title: Architecture
+{layout_line}title: Architecture
 description: How {project_name} is structured and how the pieces fit together.
 order: 1
 ---
@@ -74,8 +82,8 @@ order: 1
             format!(
                 "\
 ---
-title: {title}
-description: How {topic} works in {project_name}.
+{layout_line}title: {title}
+description: Learn about {topic} in {project_name}.
 order: 10
 ---
 
@@ -106,6 +114,7 @@ pub fn generate_default_skeletons(
     project_name: &str,
     command_groups: &[String],
     output_dir: &Path,
+    layout: Option<&str>,
 ) -> Result<Vec<GeneratedPage>, SkeletonError> {
     let mut pages = Vec::new();
 
@@ -113,7 +122,7 @@ pub fn generate_default_skeletons(
     let gs_path = output_dir.join("getting-started.mdx");
     if write_if_new(
         &gs_path,
-        &generate_skeleton(&PageTemplate::GettingStarted, project_name),
+        &generate_skeleton(&PageTemplate::GettingStarted, project_name, layout),
     )? {
         pages.push(GeneratedPage {
             path: gs_path,
@@ -126,7 +135,7 @@ pub fn generate_default_skeletons(
     let arch_path = output_dir.join("architecture.mdx");
     if write_if_new(
         &arch_path,
-        &generate_skeleton(&PageTemplate::Architecture, project_name),
+        &generate_skeleton(&PageTemplate::Architecture, project_name, layout),
     )? {
         pages.push(GeneratedPage {
             path: arch_path,
@@ -142,7 +151,10 @@ pub fn generate_default_skeletons(
         let template = PageTemplate::Concept {
             topic: group.clone(),
         };
-        if write_if_new(&concept_path, &generate_skeleton(&template, project_name))? {
+        if write_if_new(
+            &concept_path,
+            &generate_skeleton(&template, project_name, layout),
+        )? {
             pages.push(GeneratedPage {
                 path: concept_path,
                 title: capitalize(group),
@@ -185,7 +197,7 @@ mod tests {
 
     #[test]
     fn generates_getting_started_with_project_name() {
-        let mdx = generate_skeleton(&PageTemplate::GettingStarted, "legion");
+        let mdx = generate_skeleton(&PageTemplate::GettingStarted, "legion", None);
         assert!(mdx.contains("Install and start using legion"));
         assert!(mdx.contains("{/* veneer:install */}"));
         assert!(mdx.contains("{/* veneer:prerequisites */}"));
@@ -195,7 +207,7 @@ mod tests {
 
     #[test]
     fn generates_architecture_with_project_name() {
-        let mdx = generate_skeleton(&PageTemplate::Architecture, "legion");
+        let mdx = generate_skeleton(&PageTemplate::Architecture, "legion", None);
         assert!(mdx.contains("title: Architecture"));
         assert!(mdx.contains("How legion is structured"));
         assert!(mdx.contains("{/* veneer:project-structure */}"));
@@ -208,9 +220,10 @@ mod tests {
                 topic: "reflections".into(),
             },
             "legion",
+            None,
         );
         assert!(mdx.contains("title: Reflections"));
-        assert!(mdx.contains("How reflections works in legion"));
+        assert!(mdx.contains("Learn about reflections in legion"));
         assert!(mdx.contains("{/* veneer:how-it-works */}"));
     }
 
@@ -223,7 +236,7 @@ mod tests {
         fs::write(&path, "existing content").unwrap();
 
         // Try to generate -- should skip
-        let pages = generate_default_skeletons("test", &[], dir.path()).unwrap();
+        let pages = generate_default_skeletons("test", &[], dir.path(), None).unwrap();
 
         // getting-started was skipped, architecture was created
         assert_eq!(pages.len(), 1);
@@ -238,7 +251,7 @@ mod tests {
     fn generates_concept_pages_from_groups() {
         let dir = tempdir().unwrap();
         let groups = vec!["memory".to_string(), "communication".to_string()];
-        let pages = generate_default_skeletons("legion", &groups, dir.path()).unwrap();
+        let pages = generate_default_skeletons("legion", &groups, dir.path(), None).unwrap();
 
         // getting-started + architecture + 2 concepts = 4
         assert_eq!(pages.len(), 4);
@@ -248,7 +261,7 @@ mod tests {
 
     #[test]
     fn frontmatter_is_valid_yaml() {
-        let mdx = generate_skeleton(&PageTemplate::GettingStarted, "legion");
+        let mdx = generate_skeleton(&PageTemplate::GettingStarted, "legion", None);
         assert!(mdx.starts_with("---\n"));
         let end = mdx.find("\n---\n").unwrap();
         let yaml = &mdx[4..end];

--- a/crates/veneer/src/commands/extract.rs
+++ b/crates/veneer/src/commands/extract.rs
@@ -22,6 +22,10 @@ pub struct ExtractArgs {
     /// Path to the project binary for --help extraction
     #[arg(short, long)]
     binary: Option<PathBuf>,
+
+    /// Layout path to inject into MDX frontmatter (e.g., "../../layouts/Docs.astro")
+    #[arg(short, long)]
+    layout: Option<String>,
 }
 
 pub async fn run(args: ExtractArgs) -> Result<()> {
@@ -61,7 +65,7 @@ pub async fn run(args: ExtractArgs) -> Result<()> {
 
         // Phase 2: Generate reference MDX pages
         let ref_dir = args.output.clone();
-        let pages = generate_reference_pages(&root_cmd, &ref_dir)?;
+        let pages = generate_reference_pages(&root_cmd, &ref_dir, args.layout.as_deref())?;
         tracing::info!("Generated {} reference pages", pages.len());
         reference_pages = pages;
 
@@ -88,7 +92,12 @@ pub async fn run(args: ExtractArgs) -> Result<()> {
     }
 
     // Phase 4: Generate skeleton editorial pages
-    let skeletons = generate_default_skeletons(&project_name, &command_groups, &args.output)?;
+    let skeletons = generate_default_skeletons(
+        &project_name,
+        &command_groups,
+        &args.output,
+        args.layout.as_deref(),
+    )?;
     tracing::info!("Generated {} skeleton pages", skeletons.len());
 
     let total = reference_pages.len() + skeletons.len();


### PR DESCRIPTION
## Summary

- Add `--layout` flag to `veneer extract` for Astro/shingle framework integration
- Fix grammar in concept templates: "How X works" -> "Learn about X" (handles plural topics)
- Fix empty backticks in flag tables: empty short/default now show "-"
- Threads layout path through all MDX generators (reference + skeleton pages)

Supersedes #49 (rebased cleanly against main after squash merge of #48).

## Test plan

- [x] 25 unit tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Integration test: generates 63 pages from legion with layout frontmatter

Resolves #43, #44, #45, #46, #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)