### PR TITLE
feat: veneer init -- additive integration only (#67)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,6 +1133,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/veneer/Cargo.toml
+++ b/crates/veneer/Cargo.toml
@@ -19,3 +19,6 @@ tracing-subscriber = { workspace = true }
 
 veneer-adapters = { workspace = true }
 veneer-docs = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/veneer/src/commands/init.rs
+++ b/crates/veneer/src/commands/init.rs
@@ -1,0 +1,281 @@
+//! Additive init: wire veneer into a project by creating only veneer-owned files.
+//!
+//! `veneer init` never edits an authored file (`vite.config.*`, `package.json`,
+//! source files). It creates `.veneer/config.toml` and prints the one line the
+//! author adds to their own Vite config. Removing the `.veneer/` directory
+//! uninstalls veneer and leaves the project byte-for-byte as it was.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::Args;
+
+/// Relative path of the veneer-owned config file inside the project root.
+const CONFIG_RELATIVE_PATH: &str = ".veneer/config.toml";
+
+/// Contents written to `.veneer/config.toml`. Kept static so repeated inits
+/// are byte-identical and uninstall/reinstall is deterministic.
+const CONFIG_CONTENTS: &str = "\
+# Veneer configuration.
+# This file is owned by veneer. Removing the .veneer/ directory uninstalls
+# veneer and leaves every authored file byte-for-byte unchanged.
+
+[veneer]
+config_version = 1
+";
+
+#[derive(Args)]
+pub struct InitArgs {
+    /// Target project root (defaults to cwd)
+    #[arg(long)]
+    pub path: Option<PathBuf>,
+}
+
+/// The Vite config flavor found in the project root.
+///
+/// Variants are ordered to match Vite's own config resolution order
+/// (`vite.config.js`, then `.mjs`, then `.ts`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ViteConfigFlavor {
+    Js,
+    Mjs,
+    Ts,
+}
+
+impl ViteConfigFlavor {
+    const ALL: [ViteConfigFlavor; 3] = [
+        ViteConfigFlavor::Js,
+        ViteConfigFlavor::Mjs,
+        ViteConfigFlavor::Ts,
+    ];
+
+    fn file_name(self) -> &'static str {
+        match self {
+            ViteConfigFlavor::Js => "vite.config.js",
+            ViteConfigFlavor::Mjs => "vite.config.mjs",
+            ViteConfigFlavor::Ts => "vite.config.ts",
+        }
+    }
+}
+
+/// What `init` did to the project.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InitOutcome {
+    /// `.veneer/config.toml` was created.
+    Created,
+    /// `.veneer/config.toml` already existed; nothing was written.
+    AlreadyInitialized,
+}
+
+/// Detect (never modify) an existing Vite config in the project root.
+fn detect_vite_config(root: &Path) -> Option<ViteConfigFlavor> {
+    ViteConfigFlavor::ALL
+        .into_iter()
+        .find(|flavor| root.join(flavor.file_name()).is_file())
+}
+
+/// Create the veneer-owned files under `root`. Never touches authored files.
+fn init_project(root: &Path) -> Result<InitOutcome> {
+    if !root.is_dir() {
+        anyhow::bail!("Project root does not exist: {}", root.display());
+    }
+
+    let config_path = root.join(CONFIG_RELATIVE_PATH);
+    if config_path.is_file() {
+        return Ok(InitOutcome::AlreadyInitialized);
+    }
+
+    let veneer_dir = root.join(".veneer");
+    std::fs::create_dir_all(&veneer_dir)
+        .with_context(|| format!("Failed to create {}", veneer_dir.display()))?;
+    std::fs::write(&config_path, CONFIG_CONTENTS)
+        .with_context(|| format!("Failed to write {}", config_path.display()))?;
+
+    Ok(InitOutcome::Created)
+}
+
+/// The instruction printed for the author. Veneer never performs this edit.
+fn integration_instruction(flavor: Option<ViteConfigFlavor>) -> String {
+    match flavor {
+        Some(flavor) => format!(
+            "Detected {name} (veneer will never modify it).\n\
+             To integrate, add this one line to the plugins array in {name}:\n\n    \
+             veneer(),",
+            name = flavor.file_name()
+        ),
+        None => "No Vite config detected (vite.config.ts / .js / .mjs).\n\
+             When you add one, include this one line in its plugins array:\n\n    \
+             veneer(),"
+            .to_string(),
+    }
+}
+
+pub async fn run(args: InitArgs) -> Result<()> {
+    let root: PathBuf = match args.path {
+        Some(path) => path,
+        None => std::env::current_dir().context("Failed to resolve current directory")?,
+    };
+
+    let outcome = init_project(&root)?;
+    match outcome {
+        InitOutcome::Created => println!("Created {CONFIG_RELATIVE_PATH}"),
+        InitOutcome::AlreadyInitialized => {
+            println!("Already initialized ({CONFIG_RELATIVE_PATH} exists); nothing to do")
+        }
+    }
+
+    println!("{}", integration_instruction(detect_vite_config(&root)));
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    /// Snapshot every file under `root` as relative path -> exact bytes.
+    fn snapshot(root: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
+        fn walk(root: &Path, dir: &Path, out: &mut BTreeMap<PathBuf, Vec<u8>>) {
+            for entry in std::fs::read_dir(dir).expect("read_dir") {
+                let path = entry.expect("dir entry").path();
+                if path.is_dir() {
+                    walk(root, &path, out);
+                } else {
+                    let rel = path.strip_prefix(root).expect("strip_prefix").to_path_buf();
+                    out.insert(rel, std::fs::read(&path).expect("read file"));
+                }
+            }
+        }
+        let mut out = BTreeMap::new();
+        walk(root, root, &mut out);
+        out
+    }
+
+    fn fixture_project() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("vite.config.ts"),
+            "export default { plugins: [] };\n",
+        )
+        .expect("write vite config");
+        std::fs::write(dir.path().join("package.json"), "{\"name\":\"fixture\"}\n")
+            .expect("write package.json");
+        std::fs::create_dir(dir.path().join("src")).expect("mkdir src");
+        std::fs::write(dir.path().join("src/main.ts"), "console.log(1);\n")
+            .expect("write src file");
+        dir
+    }
+
+    #[test]
+    fn init_creates_only_veneer_owned_files() {
+        let dir = fixture_project();
+        let before = snapshot(dir.path());
+
+        let outcome = init_project(dir.path()).expect("init");
+        assert_eq!(outcome, InitOutcome::Created);
+
+        let after = snapshot(dir.path());
+        for (path, bytes) in &after {
+            if path.starts_with(".veneer") {
+                continue;
+            }
+            assert_eq!(
+                before.get(path),
+                Some(bytes),
+                "authored file changed: {}",
+                path.display()
+            );
+        }
+        let added: Vec<&PathBuf> = after.keys().filter(|p| !before.contains_key(*p)).collect();
+        assert_eq!(added, [&PathBuf::from(CONFIG_RELATIVE_PATH)]);
+    }
+
+    #[test]
+    fn uninstall_restores_project_byte_for_byte() {
+        let dir = fixture_project();
+        let before = snapshot(dir.path());
+
+        init_project(dir.path()).expect("init");
+        std::fs::remove_dir_all(dir.path().join(".veneer")).expect("remove .veneer");
+
+        assert_eq!(before, snapshot(dir.path()));
+    }
+
+    #[test]
+    fn second_init_is_a_noop() {
+        let dir = fixture_project();
+
+        assert_eq!(
+            init_project(dir.path()).expect("init"),
+            InitOutcome::Created
+        );
+        let after_first = snapshot(dir.path());
+
+        assert_eq!(
+            init_project(dir.path()).expect("re-init"),
+            InitOutcome::AlreadyInitialized
+        );
+        assert_eq!(after_first, snapshot(dir.path()));
+    }
+
+    #[test]
+    fn missing_project_root_errors_with_resolved_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("does-not-exist");
+
+        let err = init_project(&missing).expect_err("should fail");
+        assert!(
+            err.to_string().contains(&missing.display().to_string()),
+            "error should name the resolved path: {err}"
+        );
+    }
+
+    #[test]
+    fn detects_each_vite_config_flavor() {
+        for flavor in ViteConfigFlavor::ALL {
+            let dir = tempfile::tempdir().expect("tempdir");
+            std::fs::write(dir.path().join(flavor.file_name()), "export default {};\n")
+                .expect("write config");
+            assert_eq!(detect_vite_config(dir.path()), Some(flavor));
+        }
+
+        let empty = tempfile::tempdir().expect("tempdir");
+        assert_eq!(detect_vite_config(empty.path()), None);
+    }
+
+    #[test]
+    fn detection_follows_vite_resolution_order() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for flavor in ViteConfigFlavor::ALL {
+            std::fs::write(dir.path().join(flavor.file_name()), "export default {};\n")
+                .expect("write config");
+        }
+        assert_eq!(detect_vite_config(dir.path()), Some(ViteConfigFlavor::Js));
+    }
+
+    #[test]
+    fn instruction_names_the_detected_flavor() {
+        for flavor in ViteConfigFlavor::ALL {
+            let text = integration_instruction(Some(flavor));
+            assert!(text.contains(flavor.file_name()), "missing name in: {text}");
+            assert!(text.contains("veneer(),"));
+        }
+
+        let none = integration_instruction(None);
+        assert!(none.contains("No Vite config detected"));
+        assert!(none.contains("veneer(),"));
+    }
+
+    #[test]
+    fn vite_config_never_modified_by_init() {
+        let dir = fixture_project();
+        let config_path = dir.path().join("vite.config.ts");
+        let before = std::fs::read(&config_path).expect("read before");
+
+        init_project(dir.path()).expect("init");
+        init_project(dir.path()).expect("re-init");
+
+        assert_eq!(before, std::fs::read(&config_path).expect("read after"));
+    }
+}

--- a/crates/veneer/src/commands/init.rs
+++ b/crates/veneer/src/commands/init.rs
@@ -59,7 +59,7 @@ impl ViteConfigFlavor {
 }
 
 /// What `init` did to the project.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 enum InitOutcome {
     /// `.veneer/config.toml` was created.
     Created,
@@ -85,9 +85,10 @@ fn init_project(root: &Path) -> Result<InitOutcome> {
         return Ok(InitOutcome::AlreadyInitialized);
     }
 
-    let veneer_dir = root.join(".veneer");
-    std::fs::create_dir_all(&veneer_dir)
-        .with_context(|| format!("Failed to create {}", veneer_dir.display()))?;
+    if let Some(veneer_dir) = config_path.parent() {
+        std::fs::create_dir_all(veneer_dir)
+            .with_context(|| format!("Failed to create {}", veneer_dir.display()))?;
+    }
     std::fs::write(&config_path, CONFIG_CONTENTS)
         .with_context(|| format!("Failed to write {}", config_path.display()))?;
 

--- a/crates/veneer/src/commands/mod.rs
+++ b/crates/veneer/src/commands/mod.rs
@@ -1,3 +1,4 @@
 //! CLI command implementations.
 
 pub mod extract;
+pub mod init;

--- a/crates/veneer/src/main.rs
+++ b/crates/veneer/src/main.rs
@@ -23,6 +23,9 @@ pub struct Cli {
 enum Commands {
     /// Extract documentation from a target project
     Extract(commands::extract::ExtractArgs),
+
+    /// Add veneer to a project by creating only veneer-owned files
+    Init(commands::init::InitArgs),
 }
 
 #[tokio::main]
@@ -40,6 +43,9 @@ async fn main() -> Result<()> {
     match cli.command {
         Commands::Extract(args) => {
             commands::extract::run(args).await?;
+        }
+        Commands::Init(args) => {
+            commands::init::run(args).await?;
         }
     }
 


### PR DESCRIPTION
## Summary

Implements FR-VEN-001 (issue #67): a `veneer init` subcommand that adds veneer to a project by creating only veneer-owned files (`.veneer/config.toml`). Integration into the author's Vite config is by printed instruction -- init detects the config flavor and prints the one line the author adds themselves; veneer never edits `vite.config.*`, `package.json`, or any other authored file, so removing `.veneer/` uninstalls veneer and leaves the project byte-for-byte as it was.

## Acceptance criteria mapping

### 1. Init adds veneer without modifying any authored file; only `.veneer/**` is created

The whole write path is `init_project` (crates/veneer/src/commands/init.rs:78): it creates the `.veneer/` directory (derived from `config_path.parent()`) and writes one static file, `.veneer/config.toml`. There is no other write call in the module and nothing in the diff opens an authored file for writing, so the guarantee is structural rather than policed. The test builds a fixture project (vite.config.ts, package.json, src/main.ts), snapshots every file as path-to-bytes before and after init, asserts each pre-existing file is byte-identical, and asserts the set of added paths is exactly `[.veneer/config.toml]`.
Evidence: test `init_creates_only_veneer_owned_files` (init.rs:172); `CONFIG_RELATIVE_PATH` at init.rs:14.

### 2. Uninstalling (removing veneer-owned files) restores the project byte-for-byte

Because init only ever adds files under `.veneer/` and its config contents are a static constant (init.rs:18), deleting that directory is a complete uninstall. The test takes a full path-to-bytes snapshot of the fixture, runs init, does `remove_dir_all(.veneer)`, and asserts the post-removal snapshot equals the pre-init snapshot as whole maps -- this is the issue's "complete when" condition, verified by test.
Evidence: test `uninstall_restores_project_byte_for_byte` (init.rs:196).

### 3. Second `veneer init` produces no changes and says so

`init_project` early-returns `InitOutcome::AlreadyInitialized` (init.rs:84-86) when `.veneer/config.toml` already exists, before any filesystem write; `run` (init.rs:114) maps that outcome to the message "Already initialized (.veneer/config.toml exists); nothing to do". An existing `.veneer/` is therefore reported as a no-op, not treated as an error. The test asserts the first run returns `Created`, the second returns `AlreadyInitialized`, and the byte-level snapshot after the second run equals the snapshot after the first.
Evidence: test `second_init_is_a_noop` (init.rs:207); verified live against a scratch project (second run prints the no-op line).

### 4. Existing Vite config is detected and reported, never modified

`detect_vite_config` (init.rs:71) probes for `vite.config.js` / `.mjs` / `.ts` using only `is_file` -- it never opens the file -- and returns a `ViteConfigFlavor` enum (init.rs:39) whose variant order encodes Vite's own resolution order. `integration_instruction` (init.rs:99) names the detected file in the printed one-line instruction (`veneer(),`), and when nothing is detected init still succeeds and prints the instruction with a "No Vite config detected" note, as the error-handling section requires.
Evidence: tests `detects_each_vite_config_flavor` (init.rs:236), `detection_follows_vite_resolution_order` (init.rs:249), `instruction_names_the_detected_flavor` (init.rs:259), and `vite_config_never_modified_by_init` (init.rs:272), which asserts vite.config.ts bytes are unchanged across two inits.

### 5. All types explicit; `Result<T, E>` for fallible operations

Every fallible operation returns `Result`: `init_project` returns `Result<InitOutcome>` and `run` returns `Result<()>` (anyhow), with `root: PathBuf` annotated explicitly at init.rs:115. State flows through the `ViteConfigFlavor` and `InitOutcome` enums rather than strings or booleans. The missing-root case returns `Err` whose message contains the resolved path (init.rs:79-81), matching the issue's error-handling requirement.
Evidence: test `missing_project_root_errors_with_resolved_path` (init.rs:224) asserts the error message contains the resolved path.

### 6. No `unwrap()` in production code

The production half of the module contains zero `unwrap()` or `expect()`: fs calls use `?` with `with_context` (init.rs:88-93), and resolving the cwd default uses `.context("Failed to resolve current directory")` (init.rs:116). `expect` appears only inside the `#[cfg(test)] mod tests` block, where panicking on setup failure is the desired behavior.
Evidence: init.rs:88-93 and init.rs:116 are the only fallible production calls; `rg` for unwrap in the module hits only test code.

### 7. Passes `cargo clippy -- -D warnings` and `cargo fmt -- --check`

Both run clean on the branch (`cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt -- --check`), along with `cargo test --workspace`: 33 tests pass, the 25 pre-existing veneer-docs tests plus 8 new ones in `commands::init::tests`. The binary was also exercised end-to-end against a scratch project: create, idempotent second run, and the missing-root error all behave as specced.
Evidence: local `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt -- --check`, and `cargo test --workspace` all exit 0 on HEAD.

## Not done

- No watch/regeneration behavior (FR-VEN-005, separate issue).
- No Vite plugin implementation -- only the init/config surface; the printed `veneer(),` line is the instruction the author adds themselves once the plugin exists.
- No editing of `vite.config.*`, `package.json`, or any authored file, and no flag to opt into such editing -- the issue forbids it even behind a flag.
- No dynamic content (e.g. crate version) in `.veneer/config.toml`: contents are a static constant so repeated inits and uninstall/reinstall cycles stay byte-deterministic.
- No new runtime dependencies; only `tempfile` as a dev-dependency for the filesystem tests, matching the convention in veneer-adapters and veneer-docs.