### PR TITLE
feat: rafters namespace source reader -- never the lossy DTCG export (#68)

### DIFF
--- a/crates/veneer-adapters/src/lib.rs
+++ b/crates/veneer-adapters/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod conventions;
 pub mod generator;
 pub mod inline;
+pub mod rafters_source;
 pub mod react;
 pub mod registry;
 pub mod scope;
@@ -18,6 +19,11 @@ pub use generator::{
     generate_controls_panel, generate_passthrough_web_component, generate_web_component,
 };
 pub use inline::{parse_inline_jsx, parse_inline_jsx_all, to_custom_element, InlineJsx, PropValue};
+pub use rafters_source::{
+    read_rafters_namespace, AccessibilityMatrices, ContrastMatrix, ContrastPair,
+    IntelligenceSource, NamespaceError, NamespaceFile, NamespaceToken, OklchComponents,
+    RaftersNamespace, StructuredValue, TokenValue, UsagePatterns, UserOverride,
+};
 pub use react::{ComponentStructure, ReactAdapter};
 pub use registry::{CachedComponent, ComponentRegistry, RegistryError};
 pub use scope::{extract_classes_from_ts, scope_css};

--- a/crates/veneer-adapters/src/rafters_source.rs
+++ b/crates/veneer-adapters/src/rafters_source.rs
@@ -73,7 +73,7 @@ pub enum IntelligenceSource {
 /// fields the DTCG export drops: override reasons (`userOverride.reason`),
 /// the full OKLCH scale (`value.scale`), and accessibility matrices
 /// (`value.accessibility`).
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RaftersNamespace {
     /// Parsed namespace files keyed by namespace name (for example "color",
     /// "semantic", "motion"). A namespace whose file is absent has no entry:
@@ -124,7 +124,12 @@ pub struct NamespaceToken {
 }
 
 /// Do/never usage guidance attached to a token.
+///
+/// This shape is closed in the source schema, so unknown fields are a named
+/// parse error rather than silent data loss (open, namespace-specific fields
+/// live in [`NamespaceToken::extra`] instead).
 #[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct UsagePatterns {
     #[serde(rename = "do", default)]
     pub do_patterns: Vec<String>,
@@ -135,7 +140,7 @@ pub struct UsagePatterns {
 /// A user override of a generated token value. `reason` is the override
 /// reason FR-VEN-002 requires preserved.
 #[derive(Debug, Clone, PartialEq, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct UserOverride {
     pub reason: Option<String>,
     pub previous_value: Option<Value>,
@@ -169,6 +174,7 @@ pub struct StructuredValue {
 
 /// One step of an OKLCH scale.
 #[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct OklchComponents {
     pub l: f64,
     pub c: f64,
@@ -179,7 +185,7 @@ pub struct OklchComponents {
 /// The accessibility block of a structured color value. WCAG matrices are
 /// typed; the remaining keys (`onWhite`, `onBlack`, `apca`) are preserved
 /// verbatim in `extra`.
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AccessibilityMatrices {
     pub wcag_aa: Option<ContrastMatrix>,
     pub wcag_aaa: Option<ContrastMatrix>,
@@ -187,7 +193,8 @@ pub struct AccessibilityMatrices {
 }
 
 /// Scale-index pairs that pass a WCAG level, split by text size.
-#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ContrastMatrix {
     #[serde(default)]
     pub normal: Vec<ContrastPair>,
@@ -197,22 +204,19 @@ pub struct ContrastMatrix {
 
 /// A foreground/background pair of scale indices, serialized in the source
 /// as a two-element array `[foreground, background]`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(from = "[usize; 2]")]
 pub struct ContrastPair {
     pub foreground: usize,
     pub background: usize,
 }
 
-impl<'de> Deserialize<'de> for ContrastPair {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let [foreground, background] = <[usize; 2]>::deserialize(deserializer)?;
-        Ok(ContrastPair {
+impl From<[usize; 2]> for ContrastPair {
+    fn from([foreground, background]: [usize; 2]) -> Self {
+        ContrastPair {
             foreground,
             background,
-        })
+        }
     }
 }
 

--- a/crates/veneer-adapters/src/rafters_source.rs
+++ b/crates/veneer-adapters/src/rafters_source.rs
@@ -1,0 +1,707 @@
+//! Reader for the `.rafters/` namespace source -- the design-intelligence
+//! source of truth. Veneer reads this directly and never derives a rendered
+//! field from the lossy DTCG export when the namespace source is present
+//! (FR-VEN-002).
+//!
+//! Format grounding (verified against a real `.rafters/` directory, schema
+//! `https://rafters.studio/schemas/namespace-tokens.json`): each file under
+//! `.rafters/tokens/<namespace>.rafters.json` is an object with `$schema`,
+//! `namespace`, `version`, `generatedAt`, and a `tokens` array. The fields
+//! FR-VEN-002 names as dropped by the DTCG export exist in this source under
+//! these paths:
+//!
+//! - override reasons: `token.userOverride.reason` (with `previousValue`)
+//! - full OKLCH scale: `token.value.scale`, an array of `{l, c, h, alpha}`
+//! - accessibility matrices: `token.value.accessibility.wcagAA` /
+//!   `.wcagAAA`, each holding `normal` and `large` arrays of
+//!   `[foreground, background]` scale-index pairs
+//!
+//! A DTCG-style `$extensions` field does NOT exist in the namespace files
+//! and is therefore not modeled; nothing here is invented. Namespace-specific
+//! fields (for example `motionDuration`, `easingCurve`, `generationRule`)
+//! are preserved verbatim in [`NamespaceToken::extra`].
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use serde_json::Value;
+
+/// Errors while reading the `.rafters/` namespace source. Each variant names
+/// the file and, where available, the location of the failure. A parse
+/// failure is surfaced as an error -- never degraded to the DTCG export.
+#[derive(Debug, thiserror::Error)]
+pub enum NamespaceError {
+    /// A namespace file or directory could not be read from disk.
+    #[error("failed to read {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    /// A namespace file is not valid JSON or does not match the
+    /// namespace-tokens schema shape.
+    #[error("malformed namespace file {path} at line {line}, column {column}: {message}")]
+    Malformed {
+        path: PathBuf,
+        line: usize,
+        column: usize,
+        message: String,
+    },
+    /// A token inside an otherwise well-formed file has an invalid shape.
+    #[error("invalid token \"{token}\" in {path}: {message}")]
+    InvalidToken {
+        path: PathBuf,
+        token: String,
+        message: String,
+    },
+}
+
+/// Where design intelligence comes from. Either the `.rafters/` namespace
+/// source was found and parsed, or there is declared no source at all.
+/// There is deliberately no DTCG variant: the lossy export is never a
+/// fallback (the silent-fallback path is the defect FR-VEN-002 removes).
+#[derive(Debug, Clone, PartialEq)]
+pub enum IntelligenceSource {
+    /// `.rafters/` present and parsed.
+    Namespace(RaftersNamespace),
+    /// `.rafters/` absent -- declared, never silently substituted.
+    NoSource,
+}
+
+/// Parsed representation of the `.rafters/` namespace files, preserving the
+/// fields the DTCG export drops: override reasons (`userOverride.reason`),
+/// the full OKLCH scale (`value.scale`), and accessibility matrices
+/// (`value.accessibility`).
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct RaftersNamespace {
+    /// Parsed namespace files keyed by namespace name (for example "color",
+    /// "semantic", "motion"). A namespace whose file is absent has no entry:
+    /// absence is explicit, never guessed.
+    pub namespaces: BTreeMap<String, NamespaceFile>,
+}
+
+/// One parsed `<namespace>.rafters.json` file.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NamespaceFile {
+    /// The `$schema` URL, if declared.
+    pub schema: Option<String>,
+    /// Namespace name as declared inside the file.
+    pub namespace: String,
+    /// File format version, if declared.
+    pub version: Option<String>,
+    /// Generation timestamp of the file, if declared.
+    pub generated_at: Option<String>,
+    /// All tokens in the file, in file order.
+    pub tokens: Vec<NamespaceToken>,
+}
+
+/// One token from a namespace file. Every optional field is `None` (or
+/// empty) exactly when the source file omits it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NamespaceToken {
+    pub name: String,
+    pub value: TokenValue,
+    pub category: Option<String>,
+    pub namespace: Option<String>,
+    pub semantic_meaning: Option<String>,
+    pub usage_context: Vec<String>,
+    pub usage_patterns: Option<UsagePatterns>,
+    pub depends_on: Vec<String>,
+    pub progression_system: Option<String>,
+    pub scale_position: Option<i64>,
+    pub container_query_aware: Option<bool>,
+    pub locale_aware: Option<bool>,
+    pub requires_confirmation: Option<bool>,
+    /// A user override of a generated value, including the reason -- a field
+    /// the DTCG export drops entirely.
+    pub user_override: Option<UserOverride>,
+    pub description: Option<String>,
+    pub generated_at: Option<String>,
+    /// Namespace-specific fields preserved verbatim (for example
+    /// `motionDuration`, `easingCurve`, `trustLevel`, `generationRule`).
+    pub extra: serde_json::Map<String, Value>,
+}
+
+/// Do/never usage guidance attached to a token.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct UsagePatterns {
+    #[serde(rename = "do", default)]
+    pub do_patterns: Vec<String>,
+    #[serde(default)]
+    pub never: Vec<String>,
+}
+
+/// A user override of a generated token value. `reason` is the override
+/// reason FR-VEN-002 requires preserved.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UserOverride {
+    pub reason: Option<String>,
+    pub previous_value: Option<Value>,
+}
+
+/// A token value as it appears in the namespace source.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TokenValue {
+    /// A literal CSS-ish string, for example "oklch(0.985 0 0)" or "0ms".
+    Literal(String),
+    /// A reference to a position within a color family, for example
+    /// `{"family": "neutral", "position": "50"}`.
+    FamilyReference { family: String, position: String },
+    /// A structured color value carrying the intelligence the DTCG export
+    /// drops: the full OKLCH scale and accessibility matrices.
+    Structured(StructuredValue),
+}
+
+/// A structured (object) token value. `scale` and `accessibility` are typed
+/// because FR-VEN-002 names them; every other key is preserved verbatim in
+/// `extra` (for example `harmonies`, `intelligence`, `analysis`, `use`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct StructuredValue {
+    /// The full OKLCH scale, present on color-family and brand-color values.
+    pub scale: Option<Vec<OklchComponents>>,
+    /// Accessibility matrices, present on brand-color values.
+    pub accessibility: Option<AccessibilityMatrices>,
+    /// All remaining keys of the value object, preserved verbatim.
+    pub extra: serde_json::Map<String, Value>,
+}
+
+/// One step of an OKLCH scale.
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+pub struct OklchComponents {
+    pub l: f64,
+    pub c: f64,
+    pub h: f64,
+    pub alpha: f64,
+}
+
+/// The accessibility block of a structured color value. WCAG matrices are
+/// typed; the remaining keys (`onWhite`, `onBlack`, `apca`) are preserved
+/// verbatim in `extra`.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct AccessibilityMatrices {
+    pub wcag_aa: Option<ContrastMatrix>,
+    pub wcag_aaa: Option<ContrastMatrix>,
+    pub extra: serde_json::Map<String, Value>,
+}
+
+/// Scale-index pairs that pass a WCAG level, split by text size.
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+pub struct ContrastMatrix {
+    #[serde(default)]
+    pub normal: Vec<ContrastPair>,
+    #[serde(default)]
+    pub large: Vec<ContrastPair>,
+}
+
+/// A foreground/background pair of scale indices, serialized in the source
+/// as a two-element array `[foreground, background]`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContrastPair {
+    pub foreground: usize,
+    pub background: usize,
+}
+
+impl<'de> Deserialize<'de> for ContrastPair {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let [foreground, background] = <[usize; 2]>::deserialize(deserializer)?;
+        Ok(ContrastPair {
+            foreground,
+            background,
+        })
+    }
+}
+
+/// Read the `.rafters/` namespace source under `project_root`.
+///
+/// - `.rafters/` absent: returns [`IntelligenceSource::NoSource`]. Veneer
+///   never falls back to the DTCG export; `parse_dtcg_tokens` is not
+///   consulted anywhere on this path.
+/// - `.rafters/` present: parses every `tokens/<namespace>.rafters.json`.
+///   A partial namespace (some files missing) parses what exists; the
+///   absent namespaces simply have no entry.
+/// - Malformed input: returns a [`NamespaceError`] naming the file and
+///   location -- never degrades to the DTCG export.
+pub fn read_rafters_namespace(project_root: &Path) -> Result<IntelligenceSource, NamespaceError> {
+    let rafters_dir = project_root.join(".rafters");
+    if !rafters_dir.is_dir() {
+        return Ok(IntelligenceSource::NoSource);
+    }
+
+    let mut namespaces: BTreeMap<String, NamespaceFile> = BTreeMap::new();
+    let tokens_dir = rafters_dir.join("tokens");
+    if tokens_dir.is_dir() {
+        let entries = std::fs::read_dir(&tokens_dir).map_err(|source| NamespaceError::Io {
+            path: tokens_dir.clone(),
+            source,
+        })?;
+        for entry in entries {
+            let entry = entry.map_err(|source| NamespaceError::Io {
+                path: tokens_dir.clone(),
+                source,
+            })?;
+            let path = entry.path();
+            let is_namespace_file = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with(".rafters.json"));
+            if !is_namespace_file || !path.is_file() {
+                continue;
+            }
+            let file = parse_namespace_file(&path)?;
+            namespaces.insert(file.namespace.clone(), file);
+        }
+    }
+
+    Ok(IntelligenceSource::Namespace(RaftersNamespace {
+        namespaces,
+    }))
+}
+
+/// Raw serde shape of a `<namespace>.rafters.json` file.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawNamespaceFile {
+    #[serde(rename = "$schema")]
+    schema: Option<String>,
+    namespace: String,
+    version: Option<String>,
+    generated_at: Option<String>,
+    tokens: Vec<RawToken>,
+}
+
+/// Raw serde shape of one token. `value` stays untyped here and is converted
+/// to [`TokenValue`] in a second pass so shape failures can name the token.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawToken {
+    name: String,
+    value: Value,
+    category: Option<String>,
+    namespace: Option<String>,
+    semantic_meaning: Option<String>,
+    #[serde(default)]
+    usage_context: Vec<String>,
+    usage_patterns: Option<UsagePatterns>,
+    #[serde(default)]
+    depends_on: Vec<String>,
+    progression_system: Option<String>,
+    scale_position: Option<i64>,
+    container_query_aware: Option<bool>,
+    locale_aware: Option<bool>,
+    requires_confirmation: Option<bool>,
+    user_override: Option<UserOverride>,
+    description: Option<String>,
+    generated_at: Option<String>,
+    #[serde(flatten)]
+    extra: serde_json::Map<String, Value>,
+}
+
+fn parse_namespace_file(path: &Path) -> Result<NamespaceFile, NamespaceError> {
+    let source = std::fs::read_to_string(path).map_err(|source| NamespaceError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let raw: RawNamespaceFile =
+        serde_json::from_str(&source).map_err(|error| NamespaceError::Malformed {
+            path: path.to_path_buf(),
+            line: error.line(),
+            column: error.column(),
+            message: error.to_string(),
+        })?;
+
+    let mut tokens: Vec<NamespaceToken> = Vec::with_capacity(raw.tokens.len());
+    for raw_token in raw.tokens {
+        let value = parse_token_value(path, &raw_token.name, raw_token.value)?;
+        tokens.push(NamespaceToken {
+            name: raw_token.name,
+            value,
+            category: raw_token.category,
+            namespace: raw_token.namespace,
+            semantic_meaning: raw_token.semantic_meaning,
+            usage_context: raw_token.usage_context,
+            usage_patterns: raw_token.usage_patterns,
+            depends_on: raw_token.depends_on,
+            progression_system: raw_token.progression_system,
+            scale_position: raw_token.scale_position,
+            container_query_aware: raw_token.container_query_aware,
+            locale_aware: raw_token.locale_aware,
+            requires_confirmation: raw_token.requires_confirmation,
+            user_override: raw_token.user_override,
+            description: raw_token.description,
+            generated_at: raw_token.generated_at,
+            extra: raw_token.extra,
+        });
+    }
+
+    Ok(NamespaceFile {
+        schema: raw.schema,
+        namespace: raw.namespace,
+        version: raw.version,
+        generated_at: raw.generated_at,
+        tokens,
+    })
+}
+
+fn parse_token_value(path: &Path, token: &str, value: Value) -> Result<TokenValue, NamespaceError> {
+    match value {
+        Value::String(literal) => Ok(TokenValue::Literal(literal)),
+        Value::Object(mut object) => {
+            if object.len() == 2 {
+                if let (Some(Value::String(family)), Some(Value::String(position))) =
+                    (object.get("family"), object.get("position"))
+                {
+                    return Ok(TokenValue::FamilyReference {
+                        family: family.clone(),
+                        position: position.clone(),
+                    });
+                }
+            }
+
+            let scale = match object.remove("scale") {
+                Some(raw_scale) => Some(
+                    serde_json::from_value::<Vec<OklchComponents>>(raw_scale).map_err(|error| {
+                        NamespaceError::InvalidToken {
+                            path: path.to_path_buf(),
+                            token: token.to_string(),
+                            message: format!("invalid OKLCH scale: {error}"),
+                        }
+                    })?,
+                ),
+                None => None,
+            };
+            let accessibility = match object.remove("accessibility") {
+                Some(raw_accessibility) => {
+                    Some(parse_accessibility(path, token, raw_accessibility)?)
+                }
+                None => None,
+            };
+            Ok(TokenValue::Structured(StructuredValue {
+                scale,
+                accessibility,
+                extra: object,
+            }))
+        }
+        other => Err(NamespaceError::InvalidToken {
+            path: path.to_path_buf(),
+            token: token.to_string(),
+            message: format!(
+                "unsupported value type {}: expected a string or an object, refusing to guess",
+                json_type_name(&other)
+            ),
+        }),
+    }
+}
+
+fn parse_accessibility(
+    path: &Path,
+    token: &str,
+    value: Value,
+) -> Result<AccessibilityMatrices, NamespaceError> {
+    let Value::Object(mut object) = value else {
+        return Err(NamespaceError::InvalidToken {
+            path: path.to_path_buf(),
+            token: token.to_string(),
+            message: format!(
+                "accessibility must be an object, found {}",
+                json_type_name(&value)
+            ),
+        });
+    };
+    let mut parse_matrix = |key: &str| -> Result<Option<ContrastMatrix>, NamespaceError> {
+        match object.remove(key) {
+            Some(raw) => serde_json::from_value::<ContrastMatrix>(raw)
+                .map(Some)
+                .map_err(|error| NamespaceError::InvalidToken {
+                    path: path.to_path_buf(),
+                    token: token.to_string(),
+                    message: format!("invalid {key} matrix: {error}"),
+                }),
+            None => Ok(None),
+        }
+    };
+    let wcag_aa = parse_matrix("wcagAA")?;
+    let wcag_aaa = parse_matrix("wcagAAA")?;
+    Ok(AccessibilityMatrices {
+        wcag_aa,
+        wcag_aaa,
+        extra: object,
+    })
+}
+
+fn json_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tokens::parse_dtcg_tokens;
+
+    fn fixture(name: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/rafters_source")
+            .join(name)
+    }
+
+    fn read_namespace(name: &str) -> RaftersNamespace {
+        match read_rafters_namespace(&fixture(name)).expect("fixture must parse") {
+            IntelligenceSource::Namespace(namespace) => namespace,
+            IntelligenceSource::NoSource => panic!("fixture {name} must contain .rafters/"),
+        }
+    }
+
+    fn find_token<'a>(
+        namespace: &'a RaftersNamespace,
+        namespace_name: &str,
+        token_name: &str,
+    ) -> &'a NamespaceToken {
+        namespace
+            .namespaces
+            .get(namespace_name)
+            .unwrap_or_else(|| panic!("namespace {namespace_name} must exist"))
+            .tokens
+            .iter()
+            .find(|t| t.name == token_name)
+            .unwrap_or_else(|| panic!("token {token_name} must exist in {namespace_name}"))
+    }
+
+    #[test]
+    fn absent_rafters_dir_yields_declared_no_source_never_dtcg_fallback() {
+        let root = fixture("dtcg_only");
+        // The project HAS a DTCG export; only .rafters/ is missing.
+        assert!(root.join("tokens.dtcg.json").is_file());
+        let source = read_rafters_namespace(&root).expect("no-source read must succeed");
+        assert_eq!(source, IntelligenceSource::NoSource);
+    }
+
+    #[test]
+    fn namespace_present_reads_all_namespace_files() {
+        let namespace = read_namespace("with_namespace");
+        let names: Vec<&String> = namespace.namespaces.keys().collect();
+        assert_eq!(names, ["color", "motion", "semantic"]);
+        let color = &namespace.namespaces["color"];
+        assert_eq!(color.namespace, "color");
+        assert_eq!(color.version.as_deref(), Some("1.0.0"));
+        assert_eq!(
+            color.schema.as_deref(),
+            Some("https://rafters.studio/schemas/namespace-tokens.json")
+        );
+        assert_eq!(color.tokens.len(), 2);
+    }
+
+    #[test]
+    fn preserves_full_oklch_scale_dropped_by_dtcg() {
+        let namespace = read_namespace("with_namespace");
+        let neutral = find_token(&namespace, "color", "neutral");
+        let TokenValue::Structured(value) = &neutral.value else {
+            panic!("neutral must have a structured value");
+        };
+        let scale = value.scale.as_ref().expect("scale must be preserved");
+        assert_eq!(scale.len(), 11);
+        assert_eq!(
+            scale[0],
+            OklchComponents {
+                l: 0.985,
+                c: 0.0,
+                h: 0.0,
+                alpha: 1.0
+            }
+        );
+        assert_eq!(scale[10].l, 0.145);
+        // Non-scale keys of the value object are preserved verbatim.
+        assert_eq!(
+            value.extra.get("use").and_then(Value::as_str),
+            Some("Foundation neutral palette for backgrounds, borders, text, and UI chrome.")
+        );
+    }
+
+    #[test]
+    fn preserves_override_reason_dropped_by_dtcg() {
+        let namespace = read_namespace("with_namespace");
+        let primary = find_token(&namespace, "semantic", "primary");
+        let user_override = primary
+            .user_override
+            .as_ref()
+            .expect("userOverride must be preserved");
+        assert_eq!(
+            user_override.reason.as_deref(),
+            Some(
+                "Onboarded from --primary: Sean wants true red as primary to test onboard cascade"
+            )
+        );
+        assert!(user_override.previous_value.is_some());
+    }
+
+    #[test]
+    fn preserves_accessibility_matrices_dropped_by_dtcg() {
+        let namespace = read_namespace("with_namespace");
+        let primary = find_token(&namespace, "semantic", "primary");
+        let TokenValue::Structured(value) = &primary.value else {
+            panic!("primary must have a structured value");
+        };
+        let accessibility = value
+            .accessibility
+            .as_ref()
+            .expect("accessibility must be preserved");
+        let wcag_aa = accessibility.wcag_aa.as_ref().expect("wcagAA matrix");
+        assert_eq!(wcag_aa.normal.len(), 5);
+        assert_eq!(
+            wcag_aa.normal[0],
+            ContrastPair {
+                foreground: 0,
+                background: 7
+            }
+        );
+        assert_eq!(wcag_aa.large.len(), 4);
+        let wcag_aaa = accessibility.wcag_aaa.as_ref().expect("wcagAAA matrix");
+        assert_eq!(wcag_aaa.normal.len(), 2);
+        // Remaining accessibility data preserved verbatim.
+        assert!(accessibility.extra.contains_key("onWhite"));
+        assert!(accessibility.extra.contains_key("apca"));
+    }
+
+    #[test]
+    fn parses_family_reference_values() {
+        let namespace = read_namespace("with_namespace");
+        let background = find_token(&namespace, "semantic", "background");
+        assert_eq!(
+            background.value,
+            TokenValue::FamilyReference {
+                family: "neutral".to_string(),
+                position: "50".to_string()
+            }
+        );
+        assert_eq!(background.depends_on, ["neutral-50", "neutral-950"]);
+        assert_eq!(background.requires_confirmation, Some(false));
+    }
+
+    #[test]
+    fn preserves_usage_patterns_and_namespace_specific_fields() {
+        let namespace = read_namespace("with_namespace");
+        let instant = find_token(&namespace, "motion", "motion-duration-instant");
+        assert_eq!(instant.value, TokenValue::Literal("0ms".to_string()));
+        let patterns = instant
+            .usage_patterns
+            .as_ref()
+            .expect("usagePatterns must be preserved");
+        assert_eq!(patterns.do_patterns.len(), 2);
+        assert_eq!(patterns.never[0], "Ignore prefers-reduced-motion");
+        assert_eq!(instant.scale_position, Some(0));
+        // Motion-specific fields survive verbatim in extra.
+        assert_eq!(
+            instant.extra.get("motionDuration").and_then(Value::as_i64),
+            Some(0)
+        );
+        assert_eq!(
+            instant
+                .extra
+                .get("reducedMotionAware")
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn namespace_truth_wins_over_divergent_dtcg_export() {
+        let root = fixture("with_namespace");
+        // The fixture project carries a divergent DTCG export claiming
+        // neutral-50 is "#fafafa" -- the lossy value.
+        let dtcg_source =
+            std::fs::read_to_string(root.join("tokens.dtcg.json")).expect("dtcg fixture");
+        let dtcg = parse_dtcg_tokens(&dtcg_source).expect("dtcg fixture parses");
+        assert_eq!(dtcg.tokens[0].value, "#fafafa");
+
+        // The namespace source is what read_rafters_namespace returns; the
+        // DTCG export is never consulted and the divergence is invisible.
+        let namespace = read_namespace("with_namespace");
+        let neutral_50 = find_token(&namespace, "color", "neutral-50");
+        assert_eq!(
+            neutral_50.value,
+            TokenValue::Literal("oklch(0.985 0 0)".to_string())
+        );
+        assert_ne!(
+            neutral_50.value,
+            TokenValue::Literal(dtcg.tokens[0].value.clone())
+        );
+    }
+
+    #[test]
+    fn partial_namespace_parses_what_exists_and_leaves_absent_areas_absent() {
+        let namespace = read_namespace("partial");
+        assert_eq!(namespace.namespaces.len(), 1);
+        assert!(namespace.namespaces.contains_key("spacing"));
+        // Absent namespaces have no entry -- not defaults, not guesses.
+        assert!(!namespace.namespaces.contains_key("color"));
+        assert!(!namespace.namespaces.contains_key("semantic"));
+        // Fields the file omits are explicitly absent on the token too.
+        let spacing_0 = find_token(&namespace, "spacing", "spacing-0");
+        assert_eq!(spacing_0.semantic_meaning, None);
+        assert_eq!(spacing_0.user_override, None);
+        assert!(spacing_0.usage_context.is_empty());
+        assert_eq!(
+            spacing_0
+                .extra
+                .get("generationRule")
+                .and_then(Value::as_str),
+            Some("calc({spacing-base} * 0)")
+        );
+    }
+
+    #[test]
+    fn rafters_dir_without_tokens_dir_is_an_empty_namespace_not_no_source() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir(temp.path().join(".rafters")).expect("mkdir .rafters");
+        let source = read_rafters_namespace(temp.path()).expect("read succeeds");
+        match source {
+            IntelligenceSource::Namespace(namespace) => {
+                assert!(namespace.namespaces.is_empty());
+            }
+            IntelligenceSource::NoSource => {
+                panic!(".rafters/ exists, so the source is Namespace, not NoSource")
+            }
+        }
+    }
+
+    #[test]
+    fn malformed_json_error_names_file_and_location() {
+        let error = read_rafters_namespace(&fixture("malformed"))
+            .expect_err("malformed JSON must be an error, never a DTCG fallback");
+        match error {
+            NamespaceError::Malformed { path, line, .. } => {
+                assert!(path.ends_with(".rafters/tokens/color.rafters.json"));
+                assert!(line > 0);
+            }
+            other => panic!("expected Malformed error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unsupported_value_type_is_a_named_error_not_a_guess() {
+        let error = read_rafters_namespace(&fixture("bad_value"))
+            .expect_err("numeric token value must be a named error");
+        match error {
+            NamespaceError::InvalidToken {
+                path,
+                token,
+                message,
+            } => {
+                assert!(path.ends_with(".rafters/tokens/color.rafters.json"));
+                assert_eq!(token, "neutral-50");
+                assert!(message.contains("number"));
+            }
+            other => panic!("expected InvalidToken error, got {other:?}"),
+        }
+    }
+}

--- a/crates/veneer-adapters/tests/fixtures/rafters_source/bad_value/.rafters/tokens/color.rafters.json
+++ b/crates/veneer-adapters/tests/fixtures/rafters_source/bad_value/.rafters/tokens/color.rafters.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://rafters.studio/schemas/namespace-tokens.json",
+  "namespace": "color",
+  "version": "1.0.0",
+  "tokens": [
+    {
+      "name": "neutral-50",
+      "value": 42,
+      "category": "color",
+      "namespace": "color",
+      "containerQueryAware": true,
+      "description": "Token whose value has an unsupported JSON type"
+    }
+  ]
+}

--- a/crates/veneer-adapters/tests/fixtures/rafters_source/dtcg_only/tokens.dtcg.json
+++ b/crates/veneer-adapters/tests/fixtures/rafters_source/dtcg_only/tokens.dtcg.json
@@ -1,0 +1,10 @@
+{
+  "color": {
+    "neutral": {
+      "50": {
+        "$value": "#fafafa",
+        "$type": "color"
+      }
+    }
+  }
+}

--- a/crates/veneer-adapters/tests/fixtures/rafters_source/malformed/.rafters/tokens/color.rafters.json
+++ b/crates/veneer-adapters/tests/fixtures/rafters_source/malformed/.rafters/tokens/color.rafters.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://rafters.studio/schemas/namespace-tokens.json",
+  "namespace": "color",
+  "tokens": [
+    { "name": "neutral-50", "value": "oklch(0.985 0 0)",

--- a/crates/veneer-adapters/tests/fixtures/rafters_source/partial/.rafters/tokens/spacing.rafters.json
+++ b/crates/veneer-adapters/tests/fixtures/rafters_source/partial/.rafters/tokens/spacing.rafters.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://rafters.studio/schemas/namespace-tokens.json",
+  "namespace": "spacing",
+  "version": "1.0.0",
+  "generatedAt": "2026-03-29T22:50:41.878Z",
+  "tokens": [
+    {
+      "name": "spacing-0",
+      "value": "0",
+      "category": "spacing",
+      "namespace": "spacing",
+      "generationRule": "calc({spacing-base} * 0)",
+      "containerQueryAware": true,
+      "description": "Zero spacing"
+    }
+  ]
+}

--- a/crates/veneer-adapters/tests/fixtures/rafters_source/with_namespace/.rafters/tokens/color.rafters.json
+++ b/crates/veneer-adapters/tests/fixtures/rafters_source/with_namespace/.rafters/tokens/color.rafters.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://rafters.studio/schemas/namespace-tokens.json",
+  "namespace": "color",
+  "version": "1.0.0",
+  "generatedAt": "2026-03-29T22:50:41.876Z",
+  "tokens": [
+    {
+      "name": "neutral-50",
+      "value": "oklch(0.985 0 0)",
+      "category": "color",
+      "namespace": "color",
+      "semanticMeaning": "neutral shade at 50 level - light background range",
+      "usageContext": ["backgrounds", "cards", "surfaces", "light-mode-bg"],
+      "progressionSystem": "custom",
+      "scalePosition": 0,
+      "containerQueryAware": true,
+      "description": "neutral color at 50 position (OKLCH L=0.985)",
+      "generatedAt": "2026-03-29T22:50:41.876Z"
+    },
+    {
+      "name": "neutral",
+      "value": {
+        "name": "neutral",
+        "token": "neutral",
+        "use": "Foundation neutral palette for backgrounds, borders, text, and UI chrome.",
+        "scale": [
+          { "l": 0.985, "c": 0, "h": 0, "alpha": 1 },
+          { "l": 0.967, "c": 0, "h": 0, "alpha": 1 },
+          { "l": 0.92, "c": 0, "h": 0, "alpha": 1 },
+          { "l": 0.869, "c": 0, "h": 0, "alpha": 1 },
+          { "l": 0.707, "c": 0, "h": 0, "alpha": 1 },
+          { "l": 0.552, "c": 0, "h": 0, "alpha": 1 },
+          { "l": 0.442, "c": 0, "h": 0, "alpha": 1 },
+          { "l": 0.371, "c": 0, "h": 0, "alpha": 1 },
+          { "l": 0.269, "c": 0, "h": 0, "alpha": 1 },
+          { "l": 0.205, "c": 0, "h": 0, "alpha": 1 },
+          { "l": 0.145, "c": 0, "h": 0, "alpha": 1 }
+        ]
+      },
+      "category": "color",
+      "namespace": "color",
+      "containerQueryAware": true,
+      "description": "Neutral color family with full OKLCH scale"
+    }
+  ]
+}

--- a/crates/veneer-adapters/tests/fixtures/rafters_source/with_namespace/.rafters/tokens/motion.rafters.json
+++ b/crates/veneer-adapters/tests/fixtures/rafters_source/with_namespace/.rafters/tokens/motion.rafters.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://rafters.studio/schemas/namespace-tokens.json",
+  "namespace": "motion",
+  "version": "1.0.0",
+  "generatedAt": "2026-03-29T22:50:41.878Z",
+  "tokens": [
+    {
+      "name": "motion-duration-instant",
+      "value": "0ms",
+      "category": "motion",
+      "namespace": "motion",
+      "semanticMeaning": "Instant - no animation",
+      "usageContext": ["disabled-motion", "prefers-reduced-motion"],
+      "usagePatterns": {
+        "do": ["Use for prefers-reduced-motion", "Use for disabled animations"],
+        "never": ["Ignore prefers-reduced-motion", "Use slow animations for frequent actions"]
+      },
+      "dependsOn": [],
+      "progressionSystem": "minor-third",
+      "scalePosition": 0,
+      "mathRelationship": "0",
+      "containerQueryAware": false,
+      "reducedMotionAware": true,
+      "motionIntent": "transition",
+      "motionDuration": 0,
+      "description": "Duration instant: 0ms. Instant - no animation",
+      "generatedAt": "2026-03-29T22:50:41.878Z"
+    }
+  ]
+}

--- a/crates/veneer-adapters/tests/fixtures/rafters_source/with_namespace/.rafters/tokens/semantic.rafters.json
+++ b/crates/veneer-adapters/tests/fixtures/rafters_source/with_namespace/.rafters/tokens/semantic.rafters.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://rafters.studio/schemas/namespace-tokens.json",
+  "namespace": "semantic",
+  "version": "1.0.0",
+  "generatedAt": "2026-04-08T22:29:57.065Z",
+  "tokens": [
+    {
+      "name": "background",
+      "value": { "family": "neutral", "position": "50" },
+      "category": "color",
+      "namespace": "semantic",
+      "semanticMeaning": "Primary page background color",
+      "usageContext": ["page-bg", "app-background"],
+      "usagePatterns": {
+        "do": ["Use for main page background"],
+        "never": ["Use for interactive elements"]
+      },
+      "dependsOn": ["neutral-50", "neutral-950"],
+      "containerQueryAware": true,
+      "description": "Primary page background color. Light: neutral-50, Dark: neutral-950.",
+      "generatedAt": "2026-03-29T22:50:41.877Z",
+      "requiresConfirmation": false
+    },
+    {
+      "name": "primary",
+      "value": {
+        "name": "balanced-intense-copper",
+        "token": "primary",
+        "tokenId": "color-0.550-0.280-27",
+        "scale": [
+          { "l": 0.95, "c": 0.084, "h": 27, "alpha": 1 },
+          { "l": 0.896, "c": 0.28, "h": 27, "alpha": 1 },
+          { "l": 0.839, "c": 0.28, "h": 27, "alpha": 1 },
+          { "l": 0.78, "c": 0.28, "h": 27, "alpha": 1 },
+          { "l": 0.716, "c": 0.28, "h": 27, "alpha": 1 },
+          { "l": 0.645, "c": 0.28, "h": 27, "alpha": 1 },
+          { "l": 0.55, "c": 0.28, "h": 27, "alpha": 1 },
+          { "l": 0.45, "c": 0.28, "h": 27, "alpha": 1 },
+          { "l": 0.35, "c": 0.28, "h": 27, "alpha": 1 },
+          { "l": 0.25, "c": 0.28, "h": 27, "alpha": 1 },
+          { "l": 0.15, "c": 0.28, "h": 27, "alpha": 1 }
+        ],
+        "accessibility": {
+          "wcagAA": {
+            "normal": [[0, 7], [0, 8], [0, 9], [0, 10], [1, 8]],
+            "large": [[0, 5], [0, 6], [0, 7], [1, 6]]
+          },
+          "wcagAAA": {
+            "normal": [[0, 9], [0, 10]],
+            "large": [[0, 7], [0, 8]]
+          },
+          "onWhite": {
+            "aa": [7, 8, 9, 10],
+            "aaa": [9, 10],
+            "contrastRatio": 4.83,
+            "wcagAA": true,
+            "wcagAAA": false
+          },
+          "apca": { "minFontSize": 16, "onBlack": 42.1, "onWhite": 68.4 }
+        },
+        "analysis": {
+          "temperature": "warm",
+          "isLight": false,
+          "name": "balanced-intense-copper"
+        }
+      },
+      "category": "color",
+      "namespace": "semantic",
+      "semanticMeaning": "Primary brand color for main actions and emphasis",
+      "usageContext": ["buttons", "links", "brand"],
+      "trustLevel": "high",
+      "consequence": "reversible",
+      "usagePatterns": {
+        "do": ["Use for primary actions"],
+        "never": ["Use for destructive actions"]
+      },
+      "userOverride": {
+        "previousValue": "{\"name\":\"dim-honest-plum\"}",
+        "reason": "Onboarded from --primary: Sean wants true red as primary to test onboard cascade"
+      },
+      "dependsOn": [],
+      "containerQueryAware": true,
+      "description": "Primary brand color",
+      "generatedAt": "2026-04-08T22:29:57.065Z",
+      "requiresConfirmation": true
+    }
+  ]
+}

--- a/crates/veneer-adapters/tests/fixtures/rafters_source/with_namespace/tokens.dtcg.json
+++ b/crates/veneer-adapters/tests/fixtures/rafters_source/with_namespace/tokens.dtcg.json
@@ -1,0 +1,11 @@
+{
+  "color": {
+    "neutral": {
+      "50": {
+        "$value": "#fafafa",
+        "$type": "color",
+        "$description": "Lossy DTCG export: hex approximation, OKLCH scale and intelligence dropped"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Implements FR-VEN-002 (#68): veneer reads the `.rafters/` namespace files directly as the design-intelligence source of truth, and never derives a rendered field from the lossy DTCG export when the namespace is present. New module `crates/veneer-adapters/src/rafters_source.rs`, re-exported from `crates/veneer-adapters/src/lib.rs:22-26`.

The parser is grounded in a real `.rafters/` directory (schema `https://rafters.studio/schemas/namespace-tokens.json`); every fixture under `crates/veneer-adapters/tests/fixtures/rafters_source/` is a small excerpt of real files, not an invented format.

## Acceptance criteria mapping

### Parsed intelligence includes fields the DTCG export drops: override reasons, the full OKLCH scale, accessibility matrices

The FR names these concepts; in the real namespace files they live under different paths, and the parser models the reality rather than the literal names. Override reasons are `token.userOverride.reason`: typed as `UserOverride` (crates/veneer-adapters/src/rafters_source.rs:144-149) and proven by `preserves_override_reason_dropped_by_dtcg` (rafters_source.rs:535), which asserts the real onboarding reason string survives parsing. The full OKLCH scale is `token.value.scale`: typed as `Vec<OklchComponents>` on `StructuredValue` (rafters_source.rs:166-183) and proven by `preserves_full_oklch_scale_dropped_by_dtcg` (rafters_source.rs:509), asserting an 11-step scale with exact endpoint lightness values. Accessibility matrices are `token.value.accessibility.wcagAA`/`.wcagAAA`: typed as `AccessibilityMatrices`/`ContrastMatrix`/`ContrastPair` (rafters_source.rs:189-224) and proven by `preserves_accessibility_matrices_dropped_by_dtcg` (rafters_source.rs:552), asserting the foreground/background index pairs and that the untyped remainder (`onWhite`, `apca`) is preserved verbatim. Open-ended namespace-specific fields (`motionDuration`, `generationRule`, `harmonies`) are preserved losslessly in `extra` maps, proven by `preserves_usage_patterns_and_namespace_specific_fields` (rafters_source.rs:595). A DTCG-style `$extensions` field does not exist in the real namespace files and is deliberately not modeled -- the module doc (rafters_source.rs:19-22) records this spec-vs-reality finding instead of fabricating the field.

### No rendered field is derived from the DTCG export when the namespace source is present

`read_rafters_namespace` (rafters_source.rs:233) never calls `parse_dtcg_tokens`; the only non-doc reference to the DTCG parser in the module is the test import used to prove divergence. The test `namespace_truth_wins_over_divergent_dtcg_export` (rafters_source.rs:621) runs against a fixture project that carries BOTH a `.rafters/` source and a divergent DTCG export claiming `neutral-50` is `#fafafa`; it asserts the returned `IntelligenceSource` holds the namespace truth `oklch(0.985 0 0)` and explicitly asserts inequality with the DTCG value.

### A project without `.rafters/` yields a declared NoSource; veneer never silently falls back to the DTCG export

`IntelligenceSource` (rafters_source.rs:65-71) has exactly two variants, `Namespace` and `NoSource` -- there is structurally no DTCG variant to fall back to. `read_rafters_namespace` returns `NoSource` when `.rafters/` is not a directory (rafters_source.rs:234-237). `absent_rafters_dir_yields_declared_no_source_never_dtcg_fallback` (rafters_source.rs:485) runs against the `dtcg_only` fixture, first asserting the DTCG export file exists and is available, then asserting the result is still `NoSource`. The boundary case is pinned too: `rafters_dir_without_tokens_dir_is_an_empty_namespace_not_no_source` (rafters_source.rs:667) shows a present-but-empty `.rafters/` is a declared `Namespace` with zero entries, not `NoSource`.

### Malformed or partial namespace input produces named errors or explicit absence, never guessed values

`NamespaceError` (rafters_source.rs:34-58) has three variants, each naming the file: `Io { path }`, `Malformed { path, line, column }`, and `InvalidToken { path, token }`. `malformed_json_error_names_file_and_location` (rafters_source.rs:682) asserts truncated JSON produces `Malformed` naming `color.rafters.json` with a positive line number; `unsupported_value_type_is_a_named_error_not_a_guess` (rafters_source.rs:695) asserts a numeric token value produces `InvalidToken` naming token `neutral-50` with a "refusing to guess" message. Partial input: `partial_namespace_parses_what_exists_and_leaves_absent_areas_absent` (rafters_source.rs:645) shows a namespace with only `spacing.rafters.json` parses that file, leaves `color`/`semantic` with no map entry, and leaves omitted token fields as `None`/empty. Closed sub-shapes (`UsagePatterns`, `UserOverride`, `OklchComponents`, `ContrastMatrix`) carry `deny_unknown_fields`, so a format drift is a named error rather than silent data loss.

### All types explicit; Result<T, E> for fallible operations

Every public item is a named struct or enum with typed fields (no `any`-style bags outside the deliberate verbatim-preservation `extra: serde_json::Map<String, Value>` maps). The one fallible entry point is `pub fn read_rafters_namespace(project_root: &Path) -> Result<IntelligenceSource, NamespaceError>` (rafters_source.rs:233); the private helpers `parse_namespace_file`, `parse_token_value`, and `parse_accessibility` all return `Result<_, NamespaceError>`.

### No unwrap() in production code

Zero `unwrap()` outside `#[cfg(test)]`. Fallible spots use `map_err` into `NamespaceError` (rafters_source.rs:242-250, 309-319), `is_some_and` for the file-name filter (rafters_source.rs:255), and a match binding on `(object.get("family"), object.get("position"))` for the family-reference case instead of checked-then-unwrapped access.

### Must pass cargo clippy -- -D warnings and cargo fmt -- --check

`cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt -- --check`, and `cargo test --workspace` all pass at HEAD (91 tests in veneer-adapters, 12 of them new in `rafters_source::tests`; 25 in veneer-docs; full workspace green).

## What I deliberately did not do

- No component/composite discovery (FR-VEN-017) and no rendering of the intelligence (FR-VEN-003): the module stops at a parsed `IntelligenceSource` for those consumers to read.
- Did not delete or modify `tokens.rs` DTCG parsing: the issue scopes it as demoted, not removed. Its only involvement here is inside the new test module, where `parse_dtcg_tokens` is called to prove the fixture's DTCG export diverges from namespace truth.
- Did not parse `config.rafters.json`: it is project wiring (framework, componentsPath, exports), not design intelligence; it belongs to the discovery issue.
- Did not fabricate the FR's literally-named fields: no `overrideReason`, `accessibilityMatrix`, or `$extensions` field exists in the real namespace files, so none is invented. The real carriers (`userOverride.reason`, `value.scale`, `value.accessibility`) are parsed and typed, and the discrepancy is documented in the module doc.
- Did not add convenience accessors over the `namespaces` map: consumers do not exist yet, so helpers would be speculative.

Closes #68

Requirement: FR-VEN-002

Generated with [Claude Code](https://claude.com/claude-code)