### PR TITLE
feat: per-component preview plus compiled intelligence (#70)

### DIFF
--- a/crates/veneer-adapters/src/generator.rs
+++ b/crates/veneer-adapters/src/generator.rs
@@ -1,6 +1,19 @@
 //! Web Component code generator.
 
 use crate::react::ComponentStructure;
+use crate::traits::TransformedBlock;
+
+/// Assemble the full transform result for a component structure: the
+/// generated Web Component plus the classes and attributes the structure
+/// declares. The single assembly point for structure-based previews.
+pub fn web_component_block(tag_name: &str, structure: &ComponentStructure) -> TransformedBlock {
+    TransformedBlock {
+        web_component: generate_web_component(tag_name, structure),
+        tag_name: tag_name.to_string(),
+        classes_used: structure.collect_all_classes(),
+        attributes: structure.observed_attributes.clone(),
+    }
+}
 
 /// Generate a Web Component class from the extracted component structure.
 /// Uses adoptedStyleSheets to inherit page-level Tailwind CSS.

--- a/crates/veneer-adapters/src/intelligence.rs
+++ b/crates/veneer-adapters/src/intelligence.rs
@@ -188,8 +188,7 @@ fn render_source_item(
     item: &DiscoveredItem,
     source: &IntelligenceSource,
 ) -> Result<RenderedComponent, String> {
-    let source_text = fs::read_to_string(&item.source_path)
-        .map_err(|error| format!("failed to read {}: {error}", item.source_path.display()))?;
+    let source_text = read_source_file(&item.source_path)?;
 
     let Some((_, structure)) = extract_component_candidate(&item.source_path, &source_text) else {
         return Err(format!(
@@ -263,8 +262,7 @@ struct RenderableManifestFile {
 /// passthrough preview (the manifest declares blocks, not classes) plus
 /// the intelligence the manifest declares.
 fn render_manifest_composite(item: &DiscoveredItem) -> Result<RenderedComponent, String> {
-    let text = fs::read_to_string(&item.source_path)
-        .map_err(|error| format!("failed to read {}: {error}", item.source_path.display()))?;
+    let text = read_source_file(&item.source_path)?;
     let parsed: RenderableManifestFile = serde_json::from_str(&text).map_err(|error| {
         format!(
             "malformed composite manifest {}: {error}",
@@ -463,11 +461,15 @@ fn read_family_jsdoc(path: &Path, own_source: &str) -> Result<JsDocIntelligence,
     collect_jsdoc_intelligence(own_source, &mut merged);
 
     for sibling in family_files(path) {
-        let text = fs::read_to_string(&sibling)
-            .map_err(|error| format!("failed to read {}: {error}", sibling.display()))?;
+        let text = read_source_file(&sibling)?;
         collect_jsdoc_intelligence(&text, &mut merged);
     }
     Ok(merged)
+}
+
+/// Read a source file, naming the file in the failure reason.
+fn read_source_file(path: &Path) -> Result<String, String> {
+    fs::read_to_string(path).map_err(|error| format!("failed to read {}: {error}", path.display()))
 }
 
 /// The same-stem sibling files of a component source file, excluding the

--- a/crates/veneer-adapters/src/intelligence.rs
+++ b/crates/veneer-adapters/src/intelligence.rs
@@ -1,0 +1,1093 @@
+//! Per-component framework-less preview plus compiled intelligence
+//! (FR-VEN-003). For every discovered component and composite,
+//! [`render_component`] produces the Web Component preview (the existing
+//! `generate_web_component` pipeline -- no framework runtime referenced)
+//! together with the intelligence fields present in its source.
+//!
+//! Grounding (verified against the real rafters repo):
+//!
+//! - Component intelligence lives in JSDoc blocks using the canonical tags
+//!   from `packages/shared/src/component-intelligence.ts`:
+//!   `@cognitive-load N/10 - description`, `@usage-patterns` with
+//!   `DO:`/`NEVER:` lines (plus the legacy `@do`/`@never` tags), and
+//!   `@dependencies`. Old-constitution components
+//!   (`packages/ui/src/old/ui/*.tsx`) carry these tags; new-constitution
+//!   components (`x.behavior.ts` + framework wiring) carry none, so their
+//!   cognitive load and do/never render as absent -- never synthesized.
+//! - Composite manifests (`*.composite.json`) declare `cognitiveLoad`
+//!   (a bare number) and `usagePatterns.do` / `usagePatterns.never`.
+//! - Props are the properties a `*Props` TypeScript interface declares.
+//! - Dependencies are the external packages the source imports, plus any
+//!   packages a `@dependencies` JSDoc tag declares.
+//! - The namespace source declares no component-to-token link; the only
+//!   token references present in component source are the utility classes
+//!   themselves (for example `bg-primary` references the semantic token
+//!   `primary`). A [`TokenRef`] is therefore an exact-name match between a
+//!   class the component uses and a token the `.rafters/` namespace source
+//!   declares -- both sides real, nothing invented. With
+//!   [`IntelligenceSource::NoSource`] there are no declared tokens to
+//!   reference, so `tokens` is empty.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{Declaration, PropertyKey, Statement, TSSignature};
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
+use serde::Deserialize;
+
+use crate::generator::{generate_passthrough_web_component, web_component_block};
+use crate::rafters_source::{IntelligenceSource, UsagePatterns};
+use crate::registry::{extract_component_candidate, DiscoveredItem};
+use crate::traits::{TransformError, TransformedBlock};
+use crate::ts_helpers::normalize_whitespace;
+
+/// One property a `*Props` TypeScript interface declares. Every field is
+/// read from the declaration itself: nothing is inferred from usage.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PropDoc {
+    /// Declared property name.
+    pub name: String,
+    /// The declared type annotation, verbatim from source (whitespace
+    /// normalized). `None` when the declaration has no annotation.
+    pub type_text: Option<String>,
+    /// Whether the property is declared optional (`name?:`).
+    pub optional: bool,
+}
+
+/// One variant the component source declares, with the classes it maps to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VariantDoc {
+    /// Variant key as declared in the variant record.
+    pub name: String,
+    /// The class string that variant maps to, verbatim from source.
+    pub classes: String,
+}
+
+/// Cognitive load as declared in source: the `@cognitive-load N/10 - desc`
+/// JSDoc tag on components, or the bare `cognitiveLoad` number a composite
+/// manifest declares (which carries no description).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CognitiveLoad {
+    /// Declared score on the 0-10 scale.
+    pub score: u8,
+    /// The prose after the score, when the source declares one.
+    pub description: Option<String>,
+}
+
+/// Whether a constraint is a DO or a NEVER.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConstraintKind {
+    Do,
+    Never,
+}
+
+/// One do/never usage constraint, from `@usage-patterns` `DO:`/`NEVER:`
+/// lines, legacy `@do`/`@never` tags, or a composite manifest's
+/// `usagePatterns` block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Constraint {
+    pub kind: ConstraintKind,
+    pub text: String,
+}
+
+/// A namespace token the component's classes reference by exact name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenRef {
+    /// Token name as declared in the namespace source.
+    pub token: String,
+    /// Namespace that declares the token (for example "semantic").
+    pub namespace: String,
+    /// The component classes that reference the token, sorted.
+    pub referenced_by: Vec<String>,
+}
+
+/// Where a dependency declaration comes from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DependencyOrigin {
+    /// An `import ... from '<package>'` statement in the source file.
+    Import,
+    /// A `@dependencies` JSDoc tag.
+    JsDocTag,
+}
+
+/// One dependency the component source declares.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DependencyRef {
+    /// Package name as declared.
+    pub name: String,
+    pub origin: DependencyOrigin,
+}
+
+/// The compiled intelligence of one component or composite. Every field
+/// holds exactly what the source declares: an empty `Vec` or `None` means
+/// the source declares nothing for that field -- absent, never synthesized.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct CompiledIntelligence {
+    pub props: Vec<PropDoc>,
+    pub variants: Vec<VariantDoc>,
+    pub cognitive_load: Option<CognitiveLoad>,
+    pub do_never: Vec<Constraint>,
+    pub tokens: Vec<TokenRef>,
+    pub dependencies: Vec<DependencyRef>,
+}
+
+/// A rendered component: the framework-less Web Component preview plus its
+/// compiled intelligence.
+#[derive(Debug, Clone)]
+pub struct RenderedComponent {
+    /// Web Component preview from the existing generation pipeline.
+    pub preview: TransformedBlock,
+    pub intelligence: CompiledIntelligence,
+}
+
+/// Render one discovered component or composite: framework-less preview
+/// plus compiled intelligence. Composites go through this same path --
+/// a composite source file renders exactly like a component, and a
+/// composite manifest renders a passthrough preview with the intelligence
+/// the manifest declares.
+///
+/// Any failure is a [`TransformError::RenderFailed`] naming the item, so
+/// a failing component surfaces in coverage instead of vanishing.
+pub fn render_component(
+    item: &DiscoveredItem,
+    source: &IntelligenceSource,
+) -> Result<RenderedComponent, TransformError> {
+    render_item(item, source).map_err(|reason| TransformError::RenderFailed {
+        component: item.name.clone(),
+        reason,
+    })
+}
+
+fn render_item(
+    item: &DiscoveredItem,
+    source: &IntelligenceSource,
+) -> Result<RenderedComponent, String> {
+    let filename = item
+        .source_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            format!(
+                "source path {} has no usable file name",
+                item.source_path.display()
+            )
+        })?;
+
+    if filename.ends_with(".composite.json") {
+        return render_manifest_composite(item);
+    }
+    render_source_item(item, source)
+}
+
+/// Render an item declared by a component source file (`.tsx`, `.jsx`, or
+/// `.classes.ts`). Composite source files take exactly this path too.
+fn render_source_item(
+    item: &DiscoveredItem,
+    source: &IntelligenceSource,
+) -> Result<RenderedComponent, String> {
+    let source_text = fs::read_to_string(&item.source_path)
+        .map_err(|error| format!("failed to read {}: {error}", item.source_path.display()))?;
+
+    let Some((_, structure)) = extract_component_candidate(&item.source_path, &source_text) else {
+        return Err(format!(
+            "{} is not a renderable component source file",
+            item.source_path.display()
+        ));
+    };
+    let structure = structure.map_err(|error| {
+        format!(
+            "failed to extract a component structure from {}: {error}",
+            item.source_path.display()
+        )
+    })?;
+
+    let preview = web_component_block(&preview_tag_name(&item.name), &structure);
+
+    let module_facts = parse_module_facts(&item.source_path, &source_text)?;
+    let jsdoc = read_family_jsdoc(&item.source_path, &source_text)?;
+
+    let mut dependencies: Vec<DependencyRef> = Vec::new();
+    for import in module_facts.external_imports {
+        push_unique_dependency(&mut dependencies, import, DependencyOrigin::Import);
+    }
+    for declared in jsdoc.dependencies {
+        push_unique_dependency(&mut dependencies, declared, DependencyOrigin::JsDocTag);
+    }
+
+    let variants = structure
+        .variant_lookup
+        .iter()
+        .map(|(name, classes)| VariantDoc {
+            name: name.clone(),
+            classes: classes.clone(),
+        })
+        .collect();
+
+    let tokens = token_references(&preview.classes_used, source);
+
+    Ok(RenderedComponent {
+        preview,
+        intelligence: CompiledIntelligence {
+            props: module_facts.props,
+            variants,
+            cognitive_load: jsdoc.cognitive_load,
+            do_never: jsdoc.do_never,
+            tokens,
+            dependencies,
+        },
+    })
+}
+
+/// The subset of a `*.composite.json` manifest that declares renderable
+/// intelligence, grounded in the real manifests
+/// (`packages/ui/src/composites/*.composite.json`): `cognitiveLoad` is a
+/// bare number and `usagePatterns` holds `do`/`never` arrays. Fields the
+/// manifest does not declare stay `None` -- absent, never synthesized.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RenderableManifest {
+    cognitive_load: Option<u8>,
+    usage_patterns: Option<UsagePatterns>,
+}
+
+/// The manifest wrapper of a composite file.
+#[derive(Debug, Deserialize)]
+struct RenderableManifestFile {
+    manifest: RenderableManifest,
+}
+
+/// Render a composite declared by a `*.composite.json` manifest: a
+/// passthrough preview (the manifest declares blocks, not classes) plus
+/// the intelligence the manifest declares.
+fn render_manifest_composite(item: &DiscoveredItem) -> Result<RenderedComponent, String> {
+    let text = fs::read_to_string(&item.source_path)
+        .map_err(|error| format!("failed to read {}: {error}", item.source_path.display()))?;
+    let parsed: RenderableManifestFile = serde_json::from_str(&text).map_err(|error| {
+        format!(
+            "malformed composite manifest {}: {error}",
+            item.source_path.display()
+        )
+    })?;
+
+    let tag_name = preview_tag_name(&item.name);
+    let preview = TransformedBlock {
+        web_component: generate_passthrough_web_component(&tag_name),
+        tag_name,
+        classes_used: Vec::new(),
+        attributes: Vec::new(),
+    };
+
+    let cognitive_load = parsed.manifest.cognitive_load.map(|score| CognitiveLoad {
+        score,
+        // The manifest format declares a bare number -- there is no
+        // description in source to carry.
+        description: None,
+    });
+    let do_never = parsed
+        .manifest
+        .usage_patterns
+        .map(constraints_from_patterns)
+        .unwrap_or_default();
+
+    Ok(RenderedComponent {
+        preview,
+        intelligence: CompiledIntelligence {
+            cognitive_load,
+            do_never,
+            // A manifest declares no props interface, no variant records,
+            // no imports, and no classes; these fields are absent.
+            ..CompiledIntelligence::default()
+        },
+    })
+}
+
+fn constraints_from_patterns(patterns: UsagePatterns) -> Vec<Constraint> {
+    let dos = patterns.do_patterns.into_iter().map(|text| Constraint {
+        kind: ConstraintKind::Do,
+        text,
+    });
+    let nevers = patterns.never.into_iter().map(|text| Constraint {
+        kind: ConstraintKind::Never,
+        text,
+    });
+    dos.chain(nevers).collect()
+}
+
+fn push_unique_dependency(
+    dependencies: &mut Vec<DependencyRef>,
+    name: String,
+    origin: DependencyOrigin,
+) {
+    if !dependencies
+        .iter()
+        .any(|dep| dep.name == name && dep.origin == origin)
+    {
+        dependencies.push(DependencyRef { name, origin });
+    }
+}
+
+/// Custom element tag for an item's preview: the kebab-cased item name
+/// plus a `-preview` suffix (which also guarantees the dash a custom
+/// element name requires).
+fn preview_tag_name(name: &str) -> String {
+    let mut kebab = String::with_capacity(name.len());
+    for character in name.chars() {
+        if character.is_uppercase() {
+            if !kebab.is_empty() && !kebab.ends_with('-') {
+                kebab.push('-');
+            }
+            kebab.extend(character.to_lowercase());
+        } else if character == '_' || character == ' ' {
+            if !kebab.is_empty() && !kebab.ends_with('-') {
+                kebab.push('-');
+            }
+        } else {
+            kebab.push(character);
+        }
+    }
+    format!("{kebab}-preview")
+}
+
+// ---- module facts: props and imports, from the oxc AST ----
+
+/// Facts read directly from the source module: declared props and external
+/// imports.
+#[derive(Debug, Default)]
+struct ModuleFacts {
+    props: Vec<PropDoc>,
+    external_imports: Vec<String>,
+}
+
+/// Parse the source module for `*Props` interface declarations and import
+/// statements. The file already parsed during structure extraction, so a
+/// failure here is unexpected -- but it is still a named error, never a
+/// silent empty result.
+fn parse_module_facts(path: &Path, source: &str) -> Result<ModuleFacts, String> {
+    let source_type = if path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension == "tsx" || extension == "jsx")
+    {
+        SourceType::tsx()
+    } else {
+        SourceType::ts()
+    };
+
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, source, source_type).parse();
+    if ret.panicked || !ret.errors.is_empty() {
+        return Err(format!(
+            "failed to parse {} while reading props and imports",
+            path.display()
+        ));
+    }
+
+    let mut facts = ModuleFacts::default();
+    for statement in &ret.program.body {
+        match statement {
+            Statement::TSInterfaceDeclaration(interface) => {
+                collect_props_interface(interface, source, &mut facts.props);
+            }
+            Statement::ExportNamedDeclaration(export) => {
+                if let Some(Declaration::TSInterfaceDeclaration(interface)) = &export.declaration {
+                    collect_props_interface(interface, source, &mut facts.props);
+                }
+            }
+            Statement::ImportDeclaration(import) => {
+                let specifier = import.source.value.as_str();
+                let is_external = !specifier.starts_with('.') && !specifier.starts_with('/');
+                if is_external && !facts.external_imports.iter().any(|s| s == specifier) {
+                    facts.external_imports.push(specifier.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(facts)
+}
+
+/// Collect the properties of an interface whose name ends with "Props".
+fn collect_props_interface(
+    interface: &oxc_ast::ast::TSInterfaceDeclaration<'_>,
+    source: &str,
+    props: &mut Vec<PropDoc>,
+) {
+    if !interface.id.name.as_str().ends_with("Props") {
+        return;
+    }
+    for signature in &interface.body.body {
+        let TSSignature::TSPropertySignature(property) = signature else {
+            continue;
+        };
+        let name = match &property.key {
+            PropertyKey::StaticIdentifier(identifier) => identifier.name.as_str().to_string(),
+            PropertyKey::StringLiteral(literal) => literal.value.as_str().to_string(),
+            _ => continue,
+        };
+        let type_text = property.type_annotation.as_ref().map(|annotation| {
+            normalize_whitespace(annotation.type_annotation.span().source_text(source))
+        });
+        if !props.iter().any(|prop| prop.name == name) {
+            props.push(PropDoc {
+                name,
+                type_text,
+                optional: property.optional,
+            });
+        }
+    }
+}
+
+// ---- JSDoc intelligence: the canonical rafters tag format ----
+
+/// Intelligence read from JSDoc blocks: the canonical rafters format
+/// (`@cognitive-load`, `@usage-patterns` with `DO:`/`NEVER:` lines, legacy
+/// `@do`/`@never`, and `@dependencies`).
+#[derive(Debug, Default)]
+struct JsDocIntelligence {
+    cognitive_load: Option<CognitiveLoad>,
+    do_never: Vec<Constraint>,
+    dependencies: Vec<String>,
+}
+
+/// Read JSDoc intelligence from the item's source file and its same-stem
+/// family files. The rafters constitution (bullpen 019f1c03) splits a
+/// component across classes/behavior/wiring files, so intelligence declared
+/// on any file of the family counts: the item's own file is read first,
+/// then `<stem>.tsx` / `<stem>.jsx` / `<stem>.classes.ts` /
+/// `<stem>.behavior.ts` siblings that exist on disk.
+fn read_family_jsdoc(path: &Path, own_source: &str) -> Result<JsDocIntelligence, String> {
+    let mut merged = JsDocIntelligence::default();
+    collect_jsdoc_intelligence(own_source, &mut merged);
+
+    for sibling in family_files(path) {
+        let text = fs::read_to_string(&sibling)
+            .map_err(|error| format!("failed to read {}: {error}", sibling.display()))?;
+        collect_jsdoc_intelligence(&text, &mut merged);
+    }
+    Ok(merged)
+}
+
+/// The same-stem sibling files of a component source file, excluding the
+/// file itself. Only files that exist are returned.
+fn family_files(path: &Path) -> Vec<PathBuf> {
+    let Some(filename) = path.file_name().and_then(|name| name.to_str()) else {
+        return Vec::new();
+    };
+    let Some(parent) = path.parent() else {
+        return Vec::new();
+    };
+    let stem = filename
+        .strip_suffix(".classes.ts")
+        .or_else(|| filename.strip_suffix(".behavior.ts"))
+        .or_else(|| filename.strip_suffix(".tsx"))
+        .or_else(|| filename.strip_suffix(".jsx"))
+        .unwrap_or(filename);
+
+    [".tsx", ".jsx", ".classes.ts", ".behavior.ts"]
+        .iter()
+        .map(|suffix| parent.join(format!("{stem}{suffix}")))
+        .filter(|candidate| candidate.is_file() && candidate != path)
+        .collect()
+}
+
+/// Scan every `/** ... */` block in a source file for the canonical
+/// intelligence tags, merging into `intelligence`. Matches the merge
+/// semantics of the rafters parser: the first cognitive load wins;
+/// do/never entries append in encounter order without deduplication.
+fn collect_jsdoc_intelligence(source: &str, intelligence: &mut JsDocIntelligence) {
+    for block in jsdoc_blocks(source) {
+        for tag in jsdoc_tags(&block) {
+            match tag.name.as_str() {
+                "cognitive-load" | "cognitiveload" if intelligence.cognitive_load.is_none() => {
+                    intelligence.cognitive_load = parse_cognitive_load(&tag.value);
+                }
+                "usage-patterns" | "usagepatterns" => {
+                    parse_do_never_lines(&tag.value, &mut intelligence.do_never);
+                }
+                "do" => intelligence.do_never.push(Constraint {
+                    kind: ConstraintKind::Do,
+                    text: normalize_whitespace(&tag.value),
+                }),
+                "never" => intelligence.do_never.push(Constraint {
+                    kind: ConstraintKind::Never,
+                    text: normalize_whitespace(&tag.value),
+                }),
+                "dependencies" => {
+                    // Whitespace-separated package list; a parenthesized
+                    // remark ends the list (rafters parser behavior).
+                    for token in tag.value.split_whitespace() {
+                        if token.starts_with('(') {
+                            break;
+                        }
+                        if !intelligence.dependencies.iter().any(|dep| dep == token) {
+                            intelligence.dependencies.push(token.to_string());
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+/// Extract the text of every `/** ... */` block, with comment decoration
+/// (leading `*`) stripped per line.
+fn jsdoc_blocks(source: &str) -> Vec<String> {
+    let mut blocks = Vec::new();
+    let mut rest = source;
+    while let Some(start) = rest.find("/**") {
+        let after_open = &rest[start + 3..];
+        let Some(end) = after_open.find("*/") else {
+            break;
+        };
+        let body = &after_open[..end];
+        let cleaned: Vec<String> = body
+            .lines()
+            .map(|line| {
+                let trimmed = line.trim_start();
+                let without_star = trimmed.strip_prefix('*').unwrap_or(trimmed);
+                without_star.strip_prefix(' ').unwrap_or(without_star)
+            })
+            .map(str::to_string)
+            .collect();
+        blocks.push(cleaned.join("\n"));
+        rest = &after_open[end + 2..];
+    }
+    blocks
+}
+
+/// One `@tag value` from a JSDoc block; `value` spans until the next tag.
+struct JsDocTag {
+    name: String,
+    value: String,
+}
+
+fn jsdoc_tags(block: &str) -> Vec<JsDocTag> {
+    let mut tags: Vec<JsDocTag> = Vec::new();
+    for line in block.lines() {
+        if let Some(tag_line) = line.trim_start().strip_prefix('@') {
+            let (name, value) = match tag_line.split_once(char::is_whitespace) {
+                Some((name, value)) => (name, value.trim()),
+                None => (tag_line, ""),
+            };
+            tags.push(JsDocTag {
+                name: name.to_lowercase(),
+                value: value.to_string(),
+            });
+        } else if let Some(current) = tags.last_mut() {
+            if !current.value.is_empty() {
+                current.value.push('\n');
+            }
+            current.value.push_str(line.trim());
+        }
+    }
+    tags
+}
+
+/// Parse a `@cognitive-load` value: `N`, `N/10`, or `N/10 - description`.
+/// Scores outside 0-10 are not a valid declaration (rafters parser
+/// behavior) and yield `None`.
+fn parse_cognitive_load(value: &str) -> Option<CognitiveLoad> {
+    let trimmed = value.trim();
+    let digits_end = trimmed
+        .find(|character: char| !character.is_ascii_digit())
+        .unwrap_or(trimmed.len());
+    let score: u8 = trimmed[..digits_end].parse().ok()?;
+    if score > 10 {
+        return None;
+    }
+    let mut remainder = trimmed[digits_end..].trim_start();
+    remainder = remainder.strip_prefix("/10").unwrap_or(remainder);
+    remainder = remainder.trim_start();
+    remainder = remainder.strip_prefix('-').unwrap_or(remainder);
+    let description = normalize_whitespace(remainder);
+    Some(CognitiveLoad {
+        score,
+        description: (!description.is_empty()).then_some(description),
+    })
+}
+
+/// Parse `DO:` / `NEVER:` lines from a `@usage-patterns` value. A line
+/// that starts with neither marker continues the previous constraint.
+fn parse_do_never_lines(value: &str, constraints: &mut Vec<Constraint>) {
+    for line in value.lines() {
+        let trimmed = line.trim();
+        let (kind, text) = if let Some(text) = strip_prefix_ignore_case(trimmed, "DO:") {
+            (Some(ConstraintKind::Do), text)
+        } else if let Some(text) = strip_prefix_ignore_case(trimmed, "NEVER:") {
+            (Some(ConstraintKind::Never), text)
+        } else {
+            (None, trimmed)
+        };
+        match kind {
+            Some(kind) => constraints.push(Constraint {
+                kind,
+                text: text.trim().to_string(),
+            }),
+            None => {
+                if let Some(previous) = constraints.last_mut() {
+                    if !trimmed.is_empty() {
+                        previous.text.push(' ');
+                        previous.text.push_str(trimmed);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn strip_prefix_ignore_case<'a>(line: &'a str, prefix: &str) -> Option<&'a str> {
+    if line.len() >= prefix.len() && line[..prefix.len()].eq_ignore_ascii_case(prefix) {
+        Some(&line[prefix.len()..])
+    } else {
+        None
+    }
+}
+
+// ---- token references: classes joined to declared namespace tokens ----
+
+/// Join the classes a component uses to the tokens the namespace source
+/// declares, by exact name: a class references token `t` when its utility
+/// part (the last `:`-separated segment) equals `t` or ends with `-t`.
+/// When several declared tokens match one class, the longest names win --
+/// `ring-primary-ring` references `primary-ring`, not `ring`. Both sides
+/// of the join are declared in source; nothing is invented.
+fn token_references(classes: &[String], source: &IntelligenceSource) -> Vec<TokenRef> {
+    let IntelligenceSource::Namespace(namespace) = source else {
+        return Vec::new();
+    };
+
+    let declared: Vec<(&str, &str)> = namespace
+        .namespaces
+        .values()
+        .flat_map(|file| {
+            file.tokens
+                .iter()
+                .map(|token| (token.name.as_str(), file.namespace.as_str()))
+        })
+        .collect();
+
+    let mut hits: BTreeMap<(String, String), BTreeSet<String>> = BTreeMap::new();
+    for class in classes {
+        let utility = class.rsplit(':').next().unwrap_or(class.as_str());
+        let matches: Vec<(&str, &str)> = declared
+            .iter()
+            .copied()
+            .filter(|(token, _)| {
+                utility == *token
+                    || utility
+                        .strip_suffix(token)
+                        .is_some_and(|prefix| prefix.ends_with('-'))
+            })
+            .collect();
+        let Some(longest) = matches.iter().map(|(token, _)| token.len()).max() else {
+            continue;
+        };
+        for (token, namespace_name) in matches {
+            if token.len() == longest {
+                hits.entry((token.to_string(), namespace_name.to_string()))
+                    .or_default()
+                    .insert(class.clone());
+            }
+        }
+    }
+
+    hits.into_iter()
+        .map(|((token, namespace_name), referenced_by)| TokenRef {
+            token,
+            namespace: namespace_name,
+            referenced_by: referenced_by.into_iter().collect(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rafters_source::read_rafters_namespace;
+    use crate::registry::ComponentRegistry;
+
+    fn fixture_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/render/project")
+    }
+
+    fn discovered_items() -> (Vec<DiscoveredItem>, IntelligenceSource) {
+        let root = fixture_root();
+        let source = read_rafters_namespace(&root).expect("fixture namespace must read");
+        let items =
+            ComponentRegistry::discover(&root, &source).expect("fixture discovery must succeed");
+        (items, source)
+    }
+
+    fn item_named(items: &[DiscoveredItem], name: &str) -> DiscoveredItem {
+        items
+            .iter()
+            .find(|item| item.name.eq_ignore_ascii_case(name))
+            .unwrap_or_else(|| panic!("fixture must discover an item named {name}"))
+            .clone()
+    }
+
+    fn render_named(name: &str) -> RenderedComponent {
+        let (items, source) = discovered_items();
+        render_component(&item_named(&items, name), &source)
+            .unwrap_or_else(|error| panic!("{name} must render: {error}"))
+    }
+
+    // AC: each covered component renders a framework-less preview.
+    #[test]
+    fn component_preview_is_framework_less() {
+        let rendered = render_named("Button");
+        let preview = &rendered.preview;
+        assert_eq!(preview.tag_name, "button-preview");
+        assert!(preview.web_component.contains("extends HTMLElement"));
+        assert!(preview
+            .web_component
+            .contains("customElements.define('button-preview'"));
+        // No framework runtime referenced by the output.
+        assert!(!preview.web_component.contains("import "));
+        assert!(!preview.web_component.contains("require("));
+        assert!(!preview.web_component.to_lowercase().contains("react"));
+    }
+
+    // AC: every intelligence field present in source is exposed.
+    #[test]
+    fn exposes_every_intelligence_field_present_in_source() {
+        let rendered = render_named("Button");
+        let intelligence = &rendered.intelligence;
+
+        // Props: the ButtonProps interface declares variant, size, loading.
+        let prop_names: Vec<&str> = intelligence
+            .props
+            .iter()
+            .map(|prop| prop.name.as_str())
+            .collect();
+        assert_eq!(prop_names, ["variant", "size", "loading"]);
+        let variant_prop = &intelligence.props[0];
+        assert!(variant_prop.optional);
+        assert_eq!(
+            variant_prop.type_text.as_deref(),
+            Some("'default' | 'secondary'")
+        );
+
+        // Variants: the variantClasses record declares default + secondary.
+        let variant_names: Vec<&str> = intelligence
+            .variants
+            .iter()
+            .map(|variant| variant.name.as_str())
+            .collect();
+        assert_eq!(variant_names, ["default", "secondary"]);
+        assert!(intelligence.variants[0].classes.contains("bg-primary"));
+
+        // Cognitive load: from the @cognitive-load JSDoc tag.
+        let load = intelligence
+            .cognitive_load
+            .as_ref()
+            .expect("cognitive load is declared in the fixture JSDoc");
+        assert_eq!(load.score, 3);
+        assert_eq!(
+            load.description.as_deref(),
+            Some("Simple action trigger with clear visual hierarchy")
+        );
+
+        // Do/never: from the @usage-patterns DO:/NEVER: lines.
+        assert_eq!(intelligence.do_never.len(), 3);
+        assert_eq!(intelligence.do_never[0].kind, ConstraintKind::Do);
+        assert_eq!(
+            intelligence.do_never[0].text,
+            "Primary: main user goal, maximum 1 per section"
+        );
+        assert_eq!(intelligence.do_never[2].kind, ConstraintKind::Never);
+        assert_eq!(
+            intelligence.do_never[2].text,
+            "Multiple primary buttons competing for attention"
+        );
+
+        // Tokens: classes joined to the declared namespace tokens.
+        let token_names: Vec<&str> = intelligence
+            .tokens
+            .iter()
+            .map(|token| token.token.as_str())
+            .collect();
+        assert_eq!(
+            token_names,
+            ["primary", "primary-foreground", "primary-ring", "secondary"]
+        );
+        let primary = &intelligence.tokens[0];
+        assert_eq!(primary.namespace, "semantic");
+        assert_eq!(primary.referenced_by, ["bg-primary"]);
+        let ring = &intelligence.tokens[2];
+        assert_eq!(ring.referenced_by, ["focus-visible:ring-primary-ring"]);
+
+        // Dependencies: the react import plus the @dependencies JSDoc tag.
+        assert_eq!(
+            intelligence.dependencies,
+            [
+                DependencyRef {
+                    name: "react".to_string(),
+                    origin: DependencyOrigin::Import,
+                },
+                DependencyRef {
+                    name: "@radix-ui/react-slot".to_string(),
+                    origin: DependencyOrigin::JsDocTag,
+                },
+            ]
+        );
+    }
+
+    // AC: a field absent from source renders as absent, never synthesized.
+    #[test]
+    fn absent_fields_render_absent() {
+        let rendered = render_named("Plain");
+        let intelligence = &rendered.intelligence;
+        assert!(intelligence.props.is_empty(), "no Props interface declared");
+        assert!(
+            intelligence.variants.is_empty(),
+            "no variant record declared"
+        );
+        assert_eq!(
+            intelligence.cognitive_load, None,
+            "no @cognitive-load declared"
+        );
+        assert!(intelligence.do_never.is_empty(), "no usage patterns");
+        assert!(
+            intelligence.tokens.is_empty(),
+            "flex/gap-2 reference no declared token"
+        );
+        assert!(intelligence.dependencies.is_empty(), "no imports, no tags");
+        // The preview still renders.
+        assert!(rendered.preview.web_component.contains("plain-preview"));
+    }
+
+    // AC: fields come from the declared source; with NoSource there are no
+    // declared tokens to reference.
+    #[test]
+    fn no_source_means_no_token_references() {
+        let (items, _) = discovered_items();
+        let rendered =
+            render_component(&item_named(&items, "Button"), &IntelligenceSource::NoSource)
+                .expect("Button must render without a namespace source");
+        assert!(rendered.intelligence.tokens.is_empty());
+        // Every other field still comes from the component source itself.
+        assert!(!rendered.intelligence.props.is_empty());
+        assert!(rendered.intelligence.cognitive_load.is_some());
+    }
+
+    // AC: composites render through the same path as components.
+    #[test]
+    fn composite_source_renders_through_the_component_path() {
+        let rendered = render_named("SplitPanel");
+        assert_eq!(rendered.preview.tag_name, "split-panel-preview");
+        assert!(rendered
+            .preview
+            .web_component
+            .contains("customElements.define('split-panel-preview'"));
+        let variant_names: Vec<&str> = rendered
+            .intelligence
+            .variants
+            .iter()
+            .map(|variant| variant.name.as_str())
+            .collect();
+        assert_eq!(variant_names, ["default", "stacked"]);
+    }
+
+    // AC: composites render through the same path -- a manifest composite
+    // renders a passthrough preview plus the manifest's intelligence.
+    #[test]
+    fn composite_manifest_renders_preview_and_manifest_intelligence() {
+        let rendered = render_named("hero-banner");
+        assert_eq!(rendered.preview.tag_name, "hero-banner-preview");
+        assert!(rendered
+            .preview
+            .web_component
+            .contains("customElements.define('hero-banner-preview'"));
+        assert!(!rendered.preview.web_component.contains("import "));
+
+        let intelligence = &rendered.intelligence;
+        let load = intelligence
+            .cognitive_load
+            .as_ref()
+            .expect("manifest declares cognitiveLoad");
+        assert_eq!(load.score, 3);
+        assert_eq!(load.description, None, "manifest declares a bare number");
+        assert_eq!(intelligence.do_never.len(), 3);
+        assert_eq!(intelligence.do_never[0].kind, ConstraintKind::Do);
+        assert_eq!(intelligence.do_never[2].kind, ConstraintKind::Never);
+        // The manifest declares none of these; they are absent.
+        assert!(intelligence.props.is_empty());
+        assert!(intelligence.variants.is_empty());
+        assert!(intelligence.tokens.is_empty());
+        assert!(intelligence.dependencies.is_empty());
+    }
+
+    // AC: a component that fails to transform produces a named error,
+    // never a silent disappearance.
+    #[test]
+    fn failing_component_is_a_named_error() {
+        let (items, source) = discovered_items();
+        let error = render_component(&item_named(&items, "Broken"), &source)
+            .expect_err("an unparseable component must fail to render");
+        match &error {
+            TransformError::RenderFailed { component, .. } => {
+                assert_eq!(component, "Broken");
+            }
+            other => panic!("expected RenderFailed, got {other:?}"),
+        }
+        assert!(error.to_string().contains("Broken"), "{error}");
+    }
+
+    #[test]
+    fn installed_only_item_is_a_named_error_pointing_at_the_config() {
+        let (items, source) = discovered_items();
+        let error = render_component(&item_named(&items, "ghost-widget"), &source)
+            .expect_err("an installed name with no source file cannot render");
+        let message = error.to_string();
+        assert!(message.contains("ghost-widget"), "{message}");
+        assert!(message.contains("config.rafters.json"), "{message}");
+    }
+
+    // Every discovered item either renders or produces a named error --
+    // the full fixture project, end to end, nothing silently dropped.
+    #[test]
+    fn every_discovered_item_renders_or_errors_by_name() {
+        let (items, source) = discovered_items();
+        assert!(
+            items.len() >= 6,
+            "fixture must discover its items: {items:#?}"
+        );
+        for item in &items {
+            match render_component(item, &source) {
+                Ok(rendered) => {
+                    assert!(rendered.preview.web_component.contains("HTMLElement"));
+                }
+                Err(TransformError::RenderFailed { component, .. }) => {
+                    assert_eq!(&component, &item.name);
+                }
+                Err(other) => panic!("failures must be named RenderFailed, got {other:?}"),
+            }
+        }
+    }
+
+    // Drives the real rafters checkout when available. Run with:
+    //   VENEER_REAL_RAFTERS_ROOT=/path/to/rafters \
+    //     cargo test -p veneer-adapters -- --ignored real_rafters
+    #[test]
+    #[ignore = "requires a local rafters checkout via VENEER_REAL_RAFTERS_ROOT"]
+    fn real_rafters_components_render_or_error_by_name() {
+        let Ok(root) = std::env::var("VENEER_REAL_RAFTERS_ROOT") else {
+            eprintln!("VENEER_REAL_RAFTERS_ROOT not set; skipping");
+            return;
+        };
+        let root = PathBuf::from(root);
+        let source = read_rafters_namespace(&root).expect("real namespace must read");
+        assert!(
+            matches!(source, IntelligenceSource::Namespace(_)),
+            "the real checkout declares a .rafters/ namespace"
+        );
+        let items = ComponentRegistry::discover(&root, &source).expect("real discovery");
+        let mut rendered_count = 0usize;
+        let mut with_cognitive_load = 0usize;
+        let mut with_tokens = 0usize;
+        for item in &items {
+            match render_component(item, &source) {
+                Ok(rendered) => {
+                    rendered_count += 1;
+                    if rendered.intelligence.cognitive_load.is_some() {
+                        with_cognitive_load += 1;
+                    }
+                    if !rendered.intelligence.tokens.is_empty() {
+                        with_tokens += 1;
+                    }
+                }
+                Err(TransformError::RenderFailed { component, .. }) => {
+                    assert_eq!(&component, &item.name);
+                }
+                Err(other) => panic!("failures must be named RenderFailed, got {other:?}"),
+            }
+        }
+        eprintln!(
+            "real rafters: {} discovered, {} rendered, {} with cognitive load, {} with tokens",
+            items.len(),
+            rendered_count,
+            with_cognitive_load,
+            with_tokens
+        );
+        assert!(
+            rendered_count > 0,
+            "the real checkout must render something"
+        );
+        assert!(
+            with_cognitive_load > 0,
+            "old-constitution JSDoc must surface"
+        );
+        assert!(with_tokens > 0, "declared tokens must be referenced");
+    }
+
+    // ---- unit coverage for the parsers ----
+
+    #[test]
+    fn cognitive_load_parses_canonical_and_bare_forms() {
+        let full = parse_cognitive_load("3/10 - Simple action trigger").expect("full form");
+        assert_eq!(full.score, 3);
+        assert_eq!(full.description.as_deref(), Some("Simple action trigger"));
+
+        let bare = parse_cognitive_load("7").expect("bare form");
+        assert_eq!(bare.score, 7);
+        assert_eq!(bare.description, None);
+
+        assert_eq!(parse_cognitive_load("11/10 - impossible"), None);
+        assert_eq!(parse_cognitive_load("high"), None);
+    }
+
+    #[test]
+    fn legacy_do_never_tags_are_collected() {
+        let source = r#"
+/**
+ * Widget.
+ *
+ * @do Pair with a label
+ * @never Use for primary navigation
+ */
+export const widgetBaseClasses = 'flex';
+        "#;
+        let mut intelligence = JsDocIntelligence::default();
+        collect_jsdoc_intelligence(source, &mut intelligence);
+        assert_eq!(
+            intelligence.do_never,
+            [
+                Constraint {
+                    kind: ConstraintKind::Do,
+                    text: "Pair with a label".to_string(),
+                },
+                Constraint {
+                    kind: ConstraintKind::Never,
+                    text: "Use for primary navigation".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn preview_tag_names_are_kebab_cased() {
+        assert_eq!(preview_tag_name("Button"), "button-preview");
+        assert_eq!(preview_tag_name("SplitPanel"), "split-panel-preview");
+        assert_eq!(preview_tag_name("hero-banner"), "hero-banner-preview");
+    }
+
+    #[test]
+    fn token_matching_prefers_the_longest_declared_name() {
+        let root = fixture_root();
+        let source = read_rafters_namespace(&root).expect("fixture namespace");
+        let classes = vec![
+            "focus-visible:ring-primary-ring".to_string(),
+            "bg-primary".to_string(),
+        ];
+        let tokens = token_references(&classes, &source);
+        let names: Vec<&str> = tokens.iter().map(|token| token.token.as_str()).collect();
+        // primary-ring wins over its prefix token primary for the ring class.
+        assert_eq!(names, ["primary", "primary-ring"]);
+        assert_eq!(tokens[1].referenced_by, ["focus-visible:ring-primary-ring"]);
+    }
+}

--- a/crates/veneer-adapters/src/lib.rs
+++ b/crates/veneer-adapters/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod conventions;
 pub mod generator;
 pub mod inline;
+pub mod intelligence;
 pub mod rafters_source;
 pub mod react;
 pub mod registry;
@@ -17,8 +18,13 @@ pub(crate) mod ts_helpers;
 pub use conventions::ComponentConventions;
 pub use generator::{
     generate_controls_panel, generate_passthrough_web_component, generate_web_component,
+    web_component_block,
 };
 pub use inline::{parse_inline_jsx, parse_inline_jsx_all, to_custom_element, InlineJsx, PropValue};
+pub use intelligence::{
+    render_component, CognitiveLoad, CompiledIntelligence, Constraint, ConstraintKind,
+    DependencyOrigin, DependencyRef, PropDoc, RenderedComponent, TokenRef, VariantDoc,
+};
 pub use rafters_source::{
     read_rafters_namespace, AccessibilityMatrices, ContrastMatrix, ContrastPair,
     IntelligenceSource, NamespaceError, NamespaceFile, NamespaceToken, OklchComponents,

--- a/crates/veneer-adapters/src/registry.rs
+++ b/crates/veneer-adapters/src/registry.rs
@@ -21,10 +21,10 @@ use oxc_span::SourceType;
 use serde::Deserialize;
 use walkdir::WalkDir;
 
-use crate::generator::generate_web_component;
+use crate::generator::web_component_block;
 use crate::rafters_source::IntelligenceSource;
 use crate::react::{ComponentStructure, ReactAdapter};
-use crate::traits::TransformedBlock;
+use crate::traits::{TransformError, TransformedBlock};
 use crate::ts_helpers::{
     extract_nested_object_classes, extract_string_value, normalize_whitespace,
     unwrap_type_expressions,
@@ -545,23 +545,25 @@ fn candidate_file_kind(filename: &str, path: &Path) -> Option<SourceFileKind> {
 /// Extract a component name and, when extraction succeeds, its structure.
 ///
 /// The name comes from the source when the source declares one, falling
-/// back to the file stem. `None` for the structure means the file is
-/// present in source but nothing is generatable from it -- callers decide
-/// whether that is a skip ([`ComponentRegistry::scan`]) or an explicit
-/// not-yet-generated item ([`ComponentRegistry::discover`]).
+/// back to the file stem. An `Err` structure means the file is present in
+/// source but nothing is generatable from it, with the reason -- callers
+/// decide whether that is a skip ([`ComponentRegistry::scan`]), an
+/// explicit not-yet-generated item ([`ComponentRegistry::discover`]), or
+/// a named render failure (`render_component`).
 fn extract_from_source(
     adapter: &ReactAdapter,
     file_kind: SourceFileKind,
     filename: &str,
     path: &Path,
     source: &str,
-) -> (String, Option<ComponentStructure>) {
+) -> (String, Result<ComponentStructure, TransformError>) {
     match file_kind {
         SourceFileKind::ClassesTs => {
             let stem = filename.strip_suffix(".classes.ts").unwrap_or("unknown");
             let component_name = kebab_to_pascal(stem);
             let exports = discover_exports(source, filename);
-            let structure = build_structure_from_exports(&component_name, exports);
+            let structure = build_structure_from_exports(&component_name, exports)
+                .ok_or(TransformError::MissingVariants);
             (component_name, structure)
         }
         SourceFileKind::ComponentModule => match adapter.extract_structure(source) {
@@ -574,17 +576,37 @@ fn extract_from_source(
                 } else {
                     structure.name.clone()
                 };
-                (name, Some(structure))
+                (name, Ok(structure))
             }
-            Err(_) => {
+            Err(error) => {
                 let stem = path
                     .file_stem()
                     .and_then(|s| s.to_str())
                     .unwrap_or("unknown");
-                (kebab_to_pascal(stem), None)
+                (kebab_to_pascal(stem), Err(error))
             }
         },
     }
+}
+
+/// Classify and extract one source file as a component candidate, for
+/// callers outside the walk (`render_component`). `None` when the file is
+/// not a component source candidate at all (wrong extension, test/story
+/// file); otherwise the declared name plus the structure or the named
+/// reason it is not generatable.
+pub(crate) fn extract_component_candidate(
+    path: &Path,
+    source: &str,
+) -> Option<(String, Result<ComponentStructure, TransformError>)> {
+    let filename = path.file_name().and_then(|name| name.to_str())?;
+    let file_kind = candidate_file_kind(filename, path)?;
+    Some(extract_from_source(
+        &ReactAdapter::new(),
+        file_kind,
+        filename,
+        path,
+        source,
+    ))
 }
 
 /// Directory filter for the discovery walk: descend everywhere except
@@ -722,7 +744,7 @@ impl ComponentRegistry {
 
             let (name, structure) =
                 extract_from_source(&default_adapter, file_kind, filename, path, &source);
-            let Some(structure) = structure else {
+            let Ok(structure) = structure else {
                 continue;
             };
 
@@ -770,16 +792,7 @@ impl ComponentRegistry {
             .get(component_name)
             .ok_or_else(|| RegistryError::ComponentNotFound(component_name.to_string()))?;
 
-        let classes_used = cached.structure.collect_all_classes();
-
-        let web_component = generate_web_component(tag_name, &cached.structure);
-
-        Ok(TransformedBlock {
-            web_component,
-            tag_name: tag_name.to_string(),
-            classes_used,
-            attributes: cached.structure.observed_attributes.clone(),
-        })
+        Ok(web_component_block(tag_name, &cached.structure))
     }
 
     /// Enumerate every component and composite the project source declares
@@ -874,7 +887,7 @@ impl ComponentRegistry {
                     name,
                     kind,
                     source_path: path.to_path_buf(),
-                    generated: structure.is_some(),
+                    generated: structure.is_ok(),
                 },
             );
         }

--- a/crates/veneer-adapters/src/traits.rs
+++ b/crates/veneer-adapters/src/traits.rs
@@ -41,6 +41,12 @@ pub enum TransformError {
 
     #[error("Invalid component structure: {0}")]
     InvalidStructure(String),
+
+    /// A component or composite failed to render. Names the item so it
+    /// feeds coverage/staleness surfaces instead of silently vanishing
+    /// from the output (FR-VEN-003).
+    #[error("failed to render {component}: {reason}")]
+    RenderFailed { component: String, reason: String },
 }
 
 /// Trait for framework-specific adapters.

--- a/crates/veneer-adapters/tests/fixtures/render/project/.rafters/config.rafters.json
+++ b/crates/veneer-adapters/tests/fixtures/render/project/.rafters/config.rafters.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "componentsPath": "components",
+  "compositesPath": "composites",
+  "installed": {
+    "components": ["ghost-widget"],
+    "composites": []
+  }
+}

--- a/crates/veneer-adapters/tests/fixtures/render/project/.rafters/tokens/semantic.rafters.json
+++ b/crates/veneer-adapters/tests/fixtures/render/project/.rafters/tokens/semantic.rafters.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://rafters.studio/schemas/namespace-tokens.json",
+  "namespace": "semantic",
+  "version": "1.0.0",
+  "generatedAt": "2026-06-01T00:00:00.000Z",
+  "tokens": [
+    {
+      "name": "primary",
+      "value": "oklch(0.637 0.237 25.331)",
+      "category": "color",
+      "namespace": "semantic",
+      "semanticMeaning": "Primary brand color for main actions",
+      "usageContext": ["primary-actions", "cta"]
+    },
+    {
+      "name": "primary-foreground",
+      "value": "oklch(0.985 0 0)",
+      "category": "color",
+      "namespace": "semantic",
+      "usageContext": ["text-on-primary"]
+    },
+    {
+      "name": "primary-ring",
+      "value": "oklch(0.637 0.237 25.331)",
+      "category": "color",
+      "namespace": "semantic",
+      "usageContext": ["focus-rings"]
+    },
+    {
+      "name": "secondary",
+      "value": "oklch(0.97 0 0)",
+      "category": "color",
+      "namespace": "semantic",
+      "usageContext": ["secondary-actions"]
+    }
+  ]
+}

--- a/crates/veneer-adapters/tests/fixtures/render/project/components/broken.tsx
+++ b/crates/veneer-adapters/tests/fixtures/render/project/components/broken.tsx
@@ -1,0 +1,5 @@
+const variantClasses = {
+  default: 'bg-primary text-white',
+;
+
+export function Broken( {

--- a/crates/veneer-adapters/tests/fixtures/render/project/components/button.tsx
+++ b/crates/veneer-adapters/tests/fixtures/render/project/components/button.tsx
@@ -1,0 +1,34 @@
+/**
+ * Interactive button component for user actions
+ *
+ * @cognitive-load 3/10 - Simple action trigger with clear visual hierarchy
+ * @usage-patterns
+ * DO: Primary: main user goal, maximum 1 per section
+ * DO: Secondary: alternative paths, supporting actions
+ * NEVER: Multiple primary buttons competing for attention
+ *
+ * @dependencies @radix-ui/react-slot
+ */
+import * as React from 'react';
+
+export interface ButtonProps {
+  variant?: 'default' | 'secondary';
+  size?: 'sm' | 'lg';
+  loading?: boolean;
+}
+
+const variantClasses = {
+  default: 'bg-primary text-primary-foreground',
+  secondary: 'bg-secondary text-secondary-foreground',
+};
+
+const sizeClasses = {
+  sm: 'h-8 px-3',
+  lg: 'h-12 px-6',
+};
+
+const baseClasses = 'inline-flex items-center focus-visible:ring-primary-ring';
+
+export function Button() {
+  return <button />;
+}

--- a/crates/veneer-adapters/tests/fixtures/render/project/components/plain.classes.ts
+++ b/crates/veneer-adapters/tests/fixtures/render/project/components/plain.classes.ts
@@ -1,0 +1,1 @@
+export const plainBaseClasses = 'flex gap-2';

--- a/crates/veneer-adapters/tests/fixtures/render/project/composites/hero-banner.composite.json
+++ b/crates/veneer-adapters/tests/fixtures/render/project/composites/hero-banner.composite.json
@@ -1,0 +1,31 @@
+{
+  "manifest": {
+    "id": "hero-banner",
+    "name": "Hero Banner",
+    "category": "layout",
+    "description": "Full-width hero section with heading, subheading, and call-to-action",
+    "keywords": ["hero", "banner", "landing", "cta"],
+    "cognitiveLoad": 3,
+    "solves": "Creating a focal point for page entry and primary action",
+    "appliesWhen": ["landing pages", "marketing pages"],
+    "usagePatterns": {
+      "do": [
+        "Single clear CTA above the fold",
+        "Headline under 10 words"
+      ],
+      "never": [
+        "Multiple competing CTAs"
+      ]
+    }
+  },
+  "input": [],
+  "output": [],
+  "blocks": [
+    {
+      "id": "hero-heading",
+      "type": "heading",
+      "content": "Welcome",
+      "meta": { "level": 1 }
+    }
+  ]
+}

--- a/crates/veneer-adapters/tests/fixtures/render/project/composites/split-panel.tsx
+++ b/crates/veneer-adapters/tests/fixtures/render/project/composites/split-panel.tsx
@@ -1,0 +1,8 @@
+const variantClasses = {
+  default: 'grid grid-cols-2 gap-4',
+  stacked: 'flex flex-col gap-4',
+};
+
+export function SplitPanel() {
+  return <section />;
+}


### PR DESCRIPTION
Implements FR-VEN-003 (#70): for every discovered component and composite, `render_component` produces a framework-less Web Component preview plus the compiled intelligence its source declares -- props, variants, cognitive load, do/never, tokens, and dependencies. New module `crates/veneer-adapters/src/intelligence.rs`, re-exported from `crates/veneer-adapters/src/lib.rs:24-27`.

Intelligence locations are grounded in the real rafters repo (read-only reference): the canonical JSDoc tag format from `packages/shared/src/component-intelligence.ts` for components, `*.composite.json` manifest fields for composites, and the `.rafters/` namespace tokens (FR-VEN-002 reader, unchanged) for token references.

## Acceptance criteria mapping

### Each covered component renders a framework-less preview (no framework runtime referenced by the output)

`render_component` (crates/veneer-adapters/src/intelligence.rs:154) routes component source files through `registry::extract_component_candidate` (registry.rs:594) into `generator::web_component_block` (generator.rs:10), which wraps the existing `generate_web_component` pipeline -- a self-contained custom element class using adoptedStyleSheets, with no imports and no framework reference. Proven by `intelligence::tests::component_preview_is_framework_less`, which asserts the output extends HTMLElement, defines `button-preview`, and contains no `import `, no `require(`, and no `react` in any casing. Also driven against the real rafters checkout via the env-gated test `real_rafters_components_render_or_error_by_name`: 167 items discovered, 63 rendered as previews.

### Each covered component exposes all intelligence fields present in its source: props, variants, cognitive load, do/never, tokens, dependencies

`CompiledIntelligence` (intelligence.rs:128) carries all six, each read from a verified real declaration site. Props come from `*Props` interface declarations via `collect_props_interface` (intelligence.rs:413): name, verbatim type annotation text, and optionality. Variants come from the extracted variant record (intelligence.rs:220). Cognitive load and do/never come from the canonical rafters JSDoc tags -- `@cognitive-load N/10 - desc`, `@usage-patterns` DO:/NEVER: lines, legacy `@do`/`@never` -- parsed by `collect_jsdoc_intelligence` (intelligence.rs:502), scanning the component's same-stem family files per the rafters constitution. Tokens are the exact-name join between the classes the component uses and the tokens the `.rafters/` namespace declares (`token_references`, intelligence.rs:660; longest declared name wins, so `ring-primary-ring` resolves to `primary-ring`). Dependencies come from external import statements plus `@dependencies` JSDoc tags, each carrying its `DependencyOrigin` (intelligence.rs:212-218). Proven field-by-field by `intelligence::tests::exposes_every_intelligence_field_present_in_source` against the fixture at crates/veneer-adapters/tests/fixtures/render/project/components/button.tsx. The real-repo drive surfaced 63 components exposing declared cognitive load and 48 with token references.

### A field absent from source renders as absent -- never synthesized or invented

Absence is the type default -- `Option::None` and empty `Vec` with documented semantics (intelligence.rs:124-135) -- and no code path writes a fallback value: the manifest path explicitly leaves `description: None` because the manifest format declares a bare number (intelligence.rs:283-288), and new-constitution components, which declare no JSDoc intelligence anywhere in their classes/behavior layer (verified against the real repo), get `cognitive_load: None` and empty `do_never`. Proven by `intelligence::tests::absent_fields_render_absent` (a classes-only component with no JSDoc, no props interface, and no imports renders with every intelligence field absent while the preview still renders) and `intelligence::tests::no_source_means_no_token_references` (with `IntelligenceSource::NoSource` there are no declared tokens, so `tokens` is empty while the source-derived fields remain intact).

### Composites render through the same path as components

`render_item` dispatches on the declared file format only (intelligence.rs:164-183): a composite source file flows through the identical extraction and preview path as components, and a `*.composite.json` manifest renders a passthrough preview plus the intelligence the manifest declares (`render_manifest_composite`, intelligence.rs:265, reusing `rafters_source::UsagePatterns` for the do/never shape). Proven by `intelligence::tests::composite_source_renders_through_the_component_path` (split-panel, kinded Composite by discovery, renders with its declared `default`/`stacked` variants) and `intelligence::tests::composite_manifest_renders_preview_and_manifest_intelligence` (hero-banner: passthrough preview, cognitive load score 3 with no invented description, do/never populated, props/variants/tokens/dependencies absent).

### A component that fails to transform produces a named error, never a silent disappearance from output

New `TransformError::RenderFailed { component, reason }` (traits.rs:45-50); `render_component` wraps every failure with the item's name (intelligence.rs:158). To make the reasons real, `registry::extract_from_source` now returns `Result<ComponentStructure, TransformError>` instead of `Option` (registry.rs:556), so the underlying parse error survives into the render error instead of being swallowed. Proven by `intelligence::tests::failing_component_is_a_named_error` (unparseable source errors as RenderFailed naming "Broken"), `intelligence::tests::installed_only_item_is_a_named_error_pointing_at_the_config` (an installed name with no source file errors naming "ghost-widget" and the declaring config file), and `intelligence::tests::every_discovered_item_renders_or_errors_by_name` (the whole fixture project end-to-end: every discovered item either renders or errors under its own name -- there is no third outcome).

### All types explicit; Result<T, E> for fallible operations

Every public item is a named, fully typed struct or enum: `RenderedComponent`, `CompiledIntelligence`, `PropDoc`, `VariantDoc`, `CognitiveLoad`, `Constraint` with the `ConstraintKind` enum, `TokenRef`, and `DependencyRef` with the `DependencyOrigin` enum (intelligence.rs:47-144) -- no stringly-typed kinds. The fallible entry point is `pub fn render_component(...) -> Result<RenderedComponent, TransformError>`, and every fallible helper (`read_source_file`, `parse_module_facts`, `read_family_jsdoc`, `render_manifest_composite`) returns `Result`.

### No unwrap() in production code

Zero `unwrap()` outside `#[cfg(test)]` in the diff. Fallible spots use `?`, `ok_or_else`, and `map_err` into named errors; infallible fallbacks use `unwrap_or`/`unwrap_or_default` (for example `class.rsplit(':').next().unwrap_or(...)` at intelligence.rs:677, where `rsplit` always yields at least one segment).

### Must pass cargo clippy -- -D warnings and cargo fmt -- --check

`cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt -- --check`, and `cargo test --workspace` all pass at HEAD: 147 tests total, including 14 new tests in `intelligence::tests` (plus the env-gated real-repo drive), with no emoji anywhere in the diff.

## What I deliberately did not do

- No Shadow-DOM isolation guarantees: the preview reuses the existing adoptedStyleSheets generation untouched (FR-VEN-018 builds on this separately).
- No do/never placement on any surface: `Constraint` values are exposed as data only; nothing decides where they appear (FR-VEN-004).
- No machine-readable intelligence export for agents: no `Serialize` on the new types, no JSON output (FR-VEN-016).
- No primitive handling: the #69 decision stands; rendering only consumes `DiscoveredItem`s.
- No fabricated fields. Two spec-vs-reality notes: (1) component cognitive load and do/never exist in reality only as JSDoc tags on old-constitution components -- new-constitution components declare none anywhere in the classes/behavior layer (verified by scanning `packages/ui/src/components` and `packages/ui/src/lib` in the real repo), so they render as absent; the JSDoc reader scans the same-stem family files, so intelligence added to that layer later is picked up without code changes. (2) The namespace source declares no component-to-token link, so `TokenRef` is defined as the exact-name join between component classes and declared namespace tokens -- both sides present in source -- rather than an invented mapping.