### PR TITLE
feat: coverage tracking with honest not-yet-documented (#74)

### DIFF
--- a/crates/veneer-adapters/src/coverage.rs
+++ b/crates/veneer-adapters/src/coverage.rs
@@ -1,0 +1,329 @@
+//! Coverage tracking (FR-VEN-009): which discovered components are
+//! documented versus not yet -- honest numbers, never a blank or a 404.
+//!
+//! The denominator is the discovered set (FR-VEN-017): an item veneer
+//! never discovered cannot be reported missing, and an item veneer did
+//! discover can never silently vanish from the numbers. An item counts as
+//! documented only when discovery marked it generatable
+//! ([`DiscoveredItem::generated`]) AND the render pipeline
+//! ([`render_component`]) actually produced its preview -- a render
+//! failure counts as not-yet-documented, with its failure state, never as
+//! documented. No partial success is rounded up to "covered".
+//!
+//! Every uncovered item gets an explicit "not yet documented" placeholder
+//! artifact ([`not_yet_documented_placeholder`]): a real MDX page naming
+//! the item and the honest reason, instead of a blank page or an error.
+//!
+//! Out of scope here, by requirement: closing the coverage gap itself
+//! (FR-VEN-003 per component) and staleness marking (FR-VEN-014).
+
+use std::path::Path;
+
+use crate::intelligence::render_component;
+use crate::rafters_source::IntelligenceSource;
+use crate::registry::{ComponentRegistry, DiscoveredItem, DiscoveredKind, RegistryError};
+use crate::ts_helpers::kebab_case;
+
+/// Coverage of a discovered set: documented versus not-yet-documented,
+/// with the discovered set as the denominator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoverageReport {
+    /// Names of discovered items whose preview rendered.
+    pub documented: Vec<String>,
+    /// Names of discovered items not yet documented (nothing generatable,
+    /// or generation/render failed).
+    pub not_yet_documented: Vec<String>,
+    /// Size of the discovered set: always
+    /// `documented.len() + not_yet_documented.len()`.
+    pub total: usize,
+}
+
+impl CoverageReport {
+    /// Fold assessed items into the report. Every assessed item lands in
+    /// exactly one bucket, so the totals cannot drift from the item states.
+    pub fn from_assessed(assessed: &[AssessedItem]) -> Self {
+        let mut documented: Vec<String> = Vec::new();
+        let mut not_yet_documented: Vec<String> = Vec::new();
+        for entry in assessed {
+            match &entry.state {
+                CoverageState::Documented => documented.push(entry.item.name.clone()),
+                CoverageState::NotYetDocumented { .. } => {
+                    not_yet_documented.push(entry.item.name.clone())
+                }
+            }
+        }
+        Self {
+            total: documented.len() + not_yet_documented.len(),
+            documented,
+            not_yet_documented,
+        }
+    }
+}
+
+/// The coverage state of one discovered item.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CoverageState {
+    /// Discovery marked the item generatable and its preview rendered.
+    Documented,
+    /// Not documented yet, with the honest reason: what discovery or the
+    /// render pipeline reported for this item.
+    NotYetDocumented { reason: String },
+}
+
+/// One discovered item together with its assessed coverage state.
+#[derive(Debug, Clone)]
+pub struct AssessedItem {
+    pub item: DiscoveredItem,
+    pub state: CoverageState,
+}
+
+/// Assess the coverage of every discovered item, in the discovered order.
+///
+/// An item is [`CoverageState::Documented`] only when both gates pass:
+/// discovery marked it generatable and [`render_component`] produced its
+/// preview. Everything else is [`CoverageState::NotYetDocumented`] with
+/// the failure state as the reason -- a failed generation is never
+/// counted as documented.
+pub fn assess_coverage(items: &[DiscoveredItem], source: &IntelligenceSource) -> Vec<AssessedItem> {
+    items
+        .iter()
+        .map(|item| AssessedItem {
+            item: item.clone(),
+            state: assess_item(item, source),
+        })
+        .collect()
+}
+
+fn assess_item(item: &DiscoveredItem, source: &IntelligenceSource) -> CoverageState {
+    if !item.generated {
+        return CoverageState::NotYetDocumented {
+            reason: format!(
+                "discovered at {} but nothing is generatable from it yet",
+                item.source_path.display()
+            ),
+        };
+    }
+    match render_component(item, source) {
+        Ok(_) => CoverageState::Documented,
+        Err(error) => CoverageState::NotYetDocumented {
+            reason: error.to_string(),
+        },
+    }
+}
+
+impl ComponentRegistry {
+    /// Query coverage for a project: discover the set, assess every item,
+    /// and fold the states into a [`CoverageReport`].
+    ///
+    /// This is an associated function taking the project root, not
+    /// `&self`: the registry's scanned cache silently drops items that
+    /// fail extraction, so measuring coverage against it would violate
+    /// the discovered-set denominator. Like
+    /// [`ComponentRegistry::discover`], coverage works from the project
+    /// source directly.
+    pub fn coverage(
+        project_root: &Path,
+        source: &IntelligenceSource,
+    ) -> Result<CoverageReport, RegistryError> {
+        let items = Self::discover(project_root, source)?;
+        Ok(CoverageReport::from_assessed(&assess_coverage(
+            &items, source,
+        )))
+    }
+}
+
+/// A placeholder artifact ready to be written alongside generator output:
+/// the file name it should be emitted under and its full content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlaceholderArtifact {
+    /// Kebab-cased file name, for example `ghost-widget.mdx`.
+    pub file_name: String,
+    /// Complete MDX page content -- a real artifact, never blank.
+    pub content: String,
+}
+
+/// Build the explicit "not yet documented" placeholder artifact for one
+/// uncovered item: an MDX page (matching the extract output family) that
+/// names the item, where it was discovered, and the honest reason it is
+/// not documented yet. Emitting this page is what turns a coverage gap
+/// into a visible state instead of a blank page or a 404.
+pub fn not_yet_documented_placeholder(
+    item: &DiscoveredItem,
+    reason: &str,
+    layout: Option<&str>,
+) -> PlaceholderArtifact {
+    let layout_line = layout
+        .map(|value| format!("layout: {value}\n"))
+        .unwrap_or_default();
+    let kind = kind_label(item.kind);
+    let name = &item.name;
+    let source_path = item.source_path.display();
+
+    let content = format!(
+        "\
+---
+{layout_line}title: {name}
+description: {name} is not yet documented.
+status: not-yet-documented
+---
+
+# {name}
+
+## Not yet documented
+
+Veneer discovered this {kind} at `{source_path}` but has not documented
+it yet.
+
+Reason: {reason}
+
+This page exists so the gap is explicit: an uncovered {kind} surfaces as
+this placeholder, never as a blank page or a 404.
+"
+    );
+
+    PlaceholderArtifact {
+        file_name: format!("{}.mdx", kebab_case(name)),
+        content,
+    }
+}
+
+fn kind_label(kind: DiscoveredKind) -> &'static str {
+    match kind {
+        DiscoveredKind::Component => "component",
+        DiscoveredKind::Composite => "composite",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rafters_source::read_rafters_namespace;
+    use std::path::PathBuf;
+
+    fn fixture_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/coverage/partial")
+    }
+
+    fn assessed_fixture() -> Vec<AssessedItem> {
+        let root = fixture_root();
+        let source = read_rafters_namespace(&root).expect("fixture namespace must read");
+        let items = ComponentRegistry::discover(&root, &source).expect("fixture must discover");
+        assess_coverage(&items, &source)
+    }
+
+    // AC: coverage numbers are exact against a fixture with known partial
+    // coverage. The fixture discovers exactly three items: Button
+    // (renderable), Broken (unparseable source), ghost-widget (installed
+    // in the rafters config with no source file).
+    #[test]
+    fn coverage_numbers_are_exact_against_partial_fixture() {
+        let report = CoverageReport::from_assessed(&assessed_fixture());
+        assert_eq!(report.total, 3, "denominator is the full discovered set");
+        assert_eq!(report.documented, ["Button"]);
+        assert_eq!(report.not_yet_documented, ["Broken", "ghost-widget"]);
+    }
+
+    // AC: coverage status is queryable, with the discovered set as the
+    // denominator.
+    #[test]
+    fn coverage_is_queryable_from_the_registry() {
+        let root = fixture_root();
+        let source = read_rafters_namespace(&root).expect("fixture namespace must read");
+        let report = ComponentRegistry::coverage(&root, &source).expect("coverage must compute");
+        assert_eq!(report.total, 3);
+        assert_eq!(
+            report.total,
+            report.documented.len() + report.not_yet_documented.len(),
+            "every discovered item lands in exactly one bucket"
+        );
+    }
+
+    // AC: a component that failed generation counts as not-yet-documented
+    // (with its failure state), never as documented.
+    #[test]
+    fn failed_generation_is_not_yet_documented_with_its_failure_state() {
+        let assessed = assessed_fixture();
+        let broken = assessed
+            .iter()
+            .find(|entry| entry.item.name == "Broken")
+            .expect("Broken must be assessed");
+        match &broken.state {
+            CoverageState::NotYetDocumented { reason } => {
+                assert!(!reason.is_empty(), "the failure state must be carried");
+                assert!(
+                    reason.contains("broken.tsx"),
+                    "reason names the source: {reason}"
+                );
+            }
+            CoverageState::Documented => panic!("a failed generation must never be documented"),
+        }
+    }
+
+    // AC: a render failure on a discovery-generatable item is still
+    // not-yet-documented -- generation success at discovery time is not
+    // rounded up to covered.
+    #[test]
+    fn render_failure_is_never_documented() {
+        let item = DiscoveredItem {
+            name: "Vanished".to_string(),
+            kind: DiscoveredKind::Component,
+            source_path: PathBuf::from("/nonexistent/vanished.tsx"),
+            generated: true,
+        };
+        let assessed = assess_coverage(&[item], &IntelligenceSource::NoSource);
+        assert_eq!(assessed.len(), 1);
+        match &assessed[0].state {
+            CoverageState::NotYetDocumented { reason } => {
+                assert!(
+                    reason.contains("Vanished"),
+                    "failure names the item: {reason}"
+                );
+            }
+            CoverageState::Documented => panic!("a render failure must never be documented"),
+        }
+    }
+
+    // AC: an undocumented component surfaces an explicit "not yet
+    // documented" artifact -- a real page, not a blank.
+    #[test]
+    fn placeholder_is_a_real_explicit_artifact() {
+        let assessed = assessed_fixture();
+        let ghost = assessed
+            .iter()
+            .find(|entry| entry.item.name == "ghost-widget")
+            .expect("ghost-widget must be assessed");
+        let CoverageState::NotYetDocumented { reason } = &ghost.state else {
+            panic!("an installed name with no source cannot be documented");
+        };
+
+        let artifact = not_yet_documented_placeholder(&ghost.item, reason, None);
+        assert_eq!(artifact.file_name, "ghost-widget.mdx");
+        assert!(artifact.content.starts_with("---\n"), "real frontmatter");
+        assert!(artifact.content.contains("status: not-yet-documented"));
+        assert!(artifact.content.contains("# ghost-widget"));
+        assert!(artifact.content.contains("Not yet documented"));
+        assert!(
+            artifact.content.contains("config.rafters.json"),
+            "the honest reason names where the item is declared"
+        );
+        assert!(
+            artifact.content.trim().lines().count() > 5,
+            "a placeholder is a page, never a blank"
+        );
+    }
+
+    #[test]
+    fn placeholder_carries_the_layout_when_given() {
+        let item = DiscoveredItem {
+            name: "HeroBanner".to_string(),
+            kind: DiscoveredKind::Composite,
+            source_path: PathBuf::from("composites/hero-banner.composite.json"),
+            generated: false,
+        };
+        let artifact =
+            not_yet_documented_placeholder(&item, "no generation pipeline", Some("../Docs.astro"));
+        assert_eq!(artifact.file_name, "hero-banner.mdx");
+        assert!(artifact.content.contains("layout: ../Docs.astro"));
+        assert!(artifact.content.contains("this composite"));
+    }
+}

--- a/crates/veneer-adapters/src/coverage.rs
+++ b/crates/veneer-adapters/src/coverage.rs
@@ -84,12 +84,15 @@ pub struct AssessedItem {
 /// preview. Everything else is [`CoverageState::NotYetDocumented`] with
 /// the failure state as the reason -- a failed generation is never
 /// counted as documented.
-pub fn assess_coverage(items: &[DiscoveredItem], source: &IntelligenceSource) -> Vec<AssessedItem> {
+pub fn assess_coverage(
+    items: Vec<DiscoveredItem>,
+    source: &IntelligenceSource,
+) -> Vec<AssessedItem> {
     items
-        .iter()
+        .into_iter()
         .map(|item| AssessedItem {
-            item: item.clone(),
-            state: assess_item(item, source),
+            state: assess_item(&item, source),
+            item,
         })
         .collect()
 }
@@ -127,7 +130,7 @@ impl ComponentRegistry {
     ) -> Result<CoverageReport, RegistryError> {
         let items = Self::discover(project_root, source)?;
         Ok(CoverageReport::from_assessed(&assess_coverage(
-            &items, source,
+            items, source,
         )))
     }
 }
@@ -208,7 +211,7 @@ mod tests {
         let root = fixture_root();
         let source = read_rafters_namespace(&root).expect("fixture namespace must read");
         let items = ComponentRegistry::discover(&root, &source).expect("fixture must discover");
-        assess_coverage(&items, &source)
+        assess_coverage(items, &source)
     }
 
     // AC: coverage numbers are exact against a fixture with known partial
@@ -270,7 +273,7 @@ mod tests {
             source_path: PathBuf::from("/nonexistent/vanished.tsx"),
             generated: true,
         };
-        let assessed = assess_coverage(&[item], &IntelligenceSource::NoSource);
+        let assessed = assess_coverage(vec![item], &IntelligenceSource::NoSource);
         assert_eq!(assessed.len(), 1);
         match &assessed[0].state {
             CoverageState::NotYetDocumented { reason } => {

--- a/crates/veneer-adapters/src/coverage.rs
+++ b/crates/veneer-adapters/src/coverage.rs
@@ -4,11 +4,14 @@
 //! The denominator is the discovered set (FR-VEN-017): an item veneer
 //! never discovered cannot be reported missing, and an item veneer did
 //! discover can never silently vanish from the numbers. An item counts as
-//! documented only when discovery marked it generatable
-//! ([`DiscoveredItem::generated`]) AND the render pipeline
-//! ([`render_component`]) actually produced its preview -- a render
-//! failure counts as not-yet-documented, with its failure state, never as
-//! documented. No partial success is rounded up to "covered".
+//! documented exactly when the render pipeline ([`render_component`])
+//! actually produced its preview -- a render failure counts as
+//! not-yet-documented, with its failure state, never as documented. No
+//! partial success is rounded up to "covered". Discovery's
+//! [`DiscoveredItem::generated`] flag is deliberately not a gate here:
+//! composite manifests are discovered with `generated: false` yet render
+//! through the manifest path, so gating on the flag would mis-bucket
+//! every composite and report a false reason.
 //!
 //! Every uncovered item gets an explicit "not yet documented" placeholder
 //! artifact ([`not_yet_documented_placeholder`]): a real MDX page naming
@@ -63,7 +66,7 @@ impl CoverageReport {
 /// The coverage state of one discovered item.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CoverageState {
-    /// Discovery marked the item generatable and its preview rendered.
+    /// The render pipeline produced the item's preview.
     Documented,
     /// Not documented yet, with the honest reason: what discovery or the
     /// render pipeline reported for this item.
@@ -79,11 +82,14 @@ pub struct AssessedItem {
 
 /// Assess the coverage of every discovered item, in the discovered order.
 ///
-/// An item is [`CoverageState::Documented`] only when both gates pass:
-/// discovery marked it generatable and [`render_component`] produced its
-/// preview. Everything else is [`CoverageState::NotYetDocumented`] with
-/// the failure state as the reason -- a failed generation is never
-/// counted as documented.
+/// An item is [`CoverageState::Documented`] exactly when
+/// [`render_component`] produced its preview. Everything else is
+/// [`CoverageState::NotYetDocumented`] with the failure state as the
+/// reason -- a failed generation is never counted as documented. The
+/// render attempt is unconditional: [`DiscoveredItem::generated`] is
+/// `false` for every composite manifest even though the manifest path
+/// renders it, so short-circuiting on the flag would mis-bucket
+/// composites with a false reason.
 pub fn assess_coverage(
     items: Vec<DiscoveredItem>,
     source: &IntelligenceSource,
@@ -98,14 +104,6 @@ pub fn assess_coverage(
 }
 
 fn assess_item(item: &DiscoveredItem, source: &IntelligenceSource) -> CoverageState {
-    if !item.generated {
-        return CoverageState::NotYetDocumented {
-            reason: format!(
-                "discovered at {} but nothing is generatable from it yet",
-                item.source_path.display()
-            ),
-        };
-    }
     match render_component(item, source) {
         Ok(_) => CoverageState::Documented,
         Err(error) => CoverageState::NotYetDocumented {
@@ -134,6 +132,12 @@ impl ComponentRegistry {
         )))
     }
 }
+
+/// The frontmatter line that marks a page as a coverage placeholder.
+/// Emitters key on this to recognize the placeholder pages they own (for
+/// example to remove a stale one once its item becomes documented)
+/// without ever touching real documentation pages.
+pub const NOT_YET_DOCUMENTED_STATUS: &str = "status: not-yet-documented";
 
 /// A placeholder artifact ready to be written alongside generator output:
 /// the file name it should be emitted under and its full content.
@@ -167,7 +171,7 @@ pub fn not_yet_documented_placeholder(
 ---
 {layout_line}title: {name}
 description: {name} is not yet documented.
-status: not-yet-documented
+{NOT_YET_DOCUMENTED_STATUS}
 ---
 
 # {name}
@@ -215,15 +219,36 @@ mod tests {
     }
 
     // AC: coverage numbers are exact against a fixture with known partial
-    // coverage. The fixture discovers exactly three items: Button
-    // (renderable), Broken (unparseable source), ghost-widget (installed
-    // in the rafters config with no source file).
+    // coverage. The fixture discovers exactly four items: Button
+    // (renderable source), hero-banner (renderable composite manifest),
+    // Broken (unparseable source), ghost-widget (installed in the rafters
+    // config with no source file).
     #[test]
     fn coverage_numbers_are_exact_against_partial_fixture() {
         let report = CoverageReport::from_assessed(&assessed_fixture());
-        assert_eq!(report.total, 3, "denominator is the full discovered set");
-        assert_eq!(report.documented, ["Button"]);
+        assert_eq!(report.total, 4, "denominator is the full discovered set");
+        assert_eq!(report.documented, ["Button", "hero-banner"]);
         assert_eq!(report.not_yet_documented, ["Broken", "ghost-widget"]);
+    }
+
+    // Regression: discovery marks every composite manifest `generated:
+    // false`, yet the manifest path renders it. Coverage must attempt the
+    // render instead of short-circuiting on the flag -- otherwise no
+    // composite could ever count as documented and the placeholder would
+    // carry a false reason.
+    #[test]
+    fn composite_manifest_counts_as_documented_despite_generated_false() {
+        let assessed = assessed_fixture();
+        let composite = assessed
+            .iter()
+            .find(|entry| entry.item.name == "hero-banner")
+            .expect("the composite manifest must be assessed");
+        assert_eq!(composite.item.kind, DiscoveredKind::Composite);
+        assert!(
+            !composite.item.generated,
+            "discovery marks manifests non-generated; coverage must not trust that"
+        );
+        assert_eq!(composite.state, CoverageState::Documented);
     }
 
     // AC: coverage status is queryable, with the discovered set as the
@@ -233,7 +258,7 @@ mod tests {
         let root = fixture_root();
         let source = read_rafters_namespace(&root).expect("fixture namespace must read");
         let report = ComponentRegistry::coverage(&root, &source).expect("coverage must compute");
-        assert_eq!(report.total, 3);
+        assert_eq!(report.total, 4);
         assert_eq!(
             report.total,
             report.documented.len() + report.not_yet_documented.len(),

--- a/crates/veneer-adapters/src/intelligence.rs
+++ b/crates/veneer-adapters/src/intelligence.rs
@@ -42,7 +42,7 @@ use crate::generator::{generate_passthrough_web_component, web_component_block};
 use crate::rafters_source::{IntelligenceSource, UsagePatterns};
 use crate::registry::{extract_component_candidate, DiscoveredItem};
 use crate::traits::{TransformError, TransformedBlock};
-use crate::ts_helpers::normalize_whitespace;
+use crate::ts_helpers::{kebab_case, normalize_whitespace};
 
 /// One property a `*Props` TypeScript interface declares. Every field is
 /// read from the declaration itself: nothing is inferred from usage.
@@ -331,22 +331,7 @@ fn push_unique_dependency(
 /// plus a `-preview` suffix (which also guarantees the dash a custom
 /// element name requires).
 fn preview_tag_name(name: &str) -> String {
-    let mut kebab = String::with_capacity(name.len());
-    for character in name.chars() {
-        if character.is_uppercase() {
-            if !kebab.is_empty() && !kebab.ends_with('-') {
-                kebab.push('-');
-            }
-            kebab.extend(character.to_lowercase());
-        } else if character == '_' || character == ' ' {
-            if !kebab.is_empty() && !kebab.ends_with('-') {
-                kebab.push('-');
-            }
-        } else {
-            kebab.push(character);
-        }
-    }
-    format!("{kebab}-preview")
+    format!("{}-preview", kebab_case(name))
 }
 
 // ---- module facts: props and imports, from the oxc AST ----

--- a/crates/veneer-adapters/src/lib.rs
+++ b/crates/veneer-adapters/src/lib.rs
@@ -4,6 +4,7 @@
 //! components into static Web Components for documentation previews.
 
 pub mod conventions;
+pub mod coverage;
 pub mod generator;
 pub mod inline;
 pub mod intelligence;
@@ -16,6 +17,10 @@ pub mod traits;
 pub(crate) mod ts_helpers;
 
 pub use conventions::ComponentConventions;
+pub use coverage::{
+    assess_coverage, not_yet_documented_placeholder, AssessedItem, CoverageReport, CoverageState,
+    PlaceholderArtifact,
+};
 pub use generator::{
     generate_controls_panel, generate_passthrough_web_component, generate_web_component,
     web_component_block,

--- a/crates/veneer-adapters/src/lib.rs
+++ b/crates/veneer-adapters/src/lib.rs
@@ -19,7 +19,7 @@ pub(crate) mod ts_helpers;
 pub use conventions::ComponentConventions;
 pub use coverage::{
     assess_coverage, not_yet_documented_placeholder, AssessedItem, CoverageReport, CoverageState,
-    PlaceholderArtifact,
+    PlaceholderArtifact, NOT_YET_DOCUMENTED_STATUS,
 };
 pub use generator::{
     generate_controls_panel, generate_passthrough_web_component, generate_web_component,

--- a/crates/veneer-adapters/src/ts_helpers.rs
+++ b/crates/veneer-adapters/src/ts_helpers.rs
@@ -1,6 +1,29 @@
-//! Shared helpers for parsing TypeScript AST expressions via oxc.
+//! Shared helpers for parsing TypeScript AST expressions via oxc, plus
+//! small name-shape utilities used across the extraction pipeline.
 
 use oxc_ast::ast::{BinaryOperator, Expression, ObjectPropertyKind};
+
+/// Kebab-case an item name: `SplitPanel` -> `split-panel`,
+/// `hero-banner` -> `hero-banner`. Underscores and spaces become dashes;
+/// consecutive separators collapse.
+pub(crate) fn kebab_case(name: &str) -> String {
+    let mut kebab = String::with_capacity(name.len());
+    for character in name.chars() {
+        if character.is_uppercase() {
+            if !kebab.is_empty() && !kebab.ends_with('-') {
+                kebab.push('-');
+            }
+            kebab.extend(character.to_lowercase());
+        } else if character == '_' || character == ' ' {
+            if !kebab.is_empty() && !kebab.ends_with('-') {
+                kebab.push('-');
+            }
+        } else {
+            kebab.push(character);
+        }
+    }
+    kebab
+}
 
 /// Unwrap TSAsExpression, TSSatisfiesExpression, TSTypeAssertion, and
 /// ParenthesizedExpression to reach the underlying value expression.

--- a/crates/veneer-adapters/tests/fixtures/coverage/partial/.rafters/config.rafters.json
+++ b/crates/veneer-adapters/tests/fixtures/coverage/partial/.rafters/config.rafters.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0.0",
+  "componentsPath": "components",
+  "installed": {
+    "components": ["ghost-widget"],
+    "composites": []
+  }
+}

--- a/crates/veneer-adapters/tests/fixtures/coverage/partial/.rafters/tokens/semantic.rafters.json
+++ b/crates/veneer-adapters/tests/fixtures/coverage/partial/.rafters/tokens/semantic.rafters.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://rafters.studio/schemas/namespace-tokens.json",
+  "namespace": "semantic",
+  "version": "1.0.0",
+  "generatedAt": "2026-06-01T00:00:00.000Z",
+  "tokens": [
+    {
+      "name": "primary",
+      "value": "oklch(0.637 0.237 25.331)",
+      "category": "color",
+      "namespace": "semantic",
+      "usageContext": ["primary-actions"]
+    },
+    {
+      "name": "secondary",
+      "value": "oklch(0.97 0 0)",
+      "category": "color",
+      "namespace": "semantic",
+      "usageContext": ["secondary-actions"]
+    }
+  ]
+}

--- a/crates/veneer-adapters/tests/fixtures/coverage/partial/components/broken.tsx
+++ b/crates/veneer-adapters/tests/fixtures/coverage/partial/components/broken.tsx
@@ -1,0 +1,5 @@
+const variantClasses = {
+  default: 'bg-primary text-white',
+;
+
+export function Broken( {

--- a/crates/veneer-adapters/tests/fixtures/coverage/partial/components/button.tsx
+++ b/crates/veneer-adapters/tests/fixtures/coverage/partial/components/button.tsx
@@ -1,0 +1,12 @@
+export interface ButtonProps {
+  variant?: 'default' | 'secondary';
+}
+
+const variantClasses = {
+  default: 'bg-primary text-primary-foreground',
+  secondary: 'bg-secondary text-secondary-foreground',
+};
+
+export function Button() {
+  return <button />;
+}

--- a/crates/veneer-adapters/tests/fixtures/coverage/partial/composites/hero-banner.composite.json
+++ b/crates/veneer-adapters/tests/fixtures/coverage/partial/composites/hero-banner.composite.json
@@ -1,0 +1,23 @@
+{
+  "manifest": {
+    "id": "hero-banner",
+    "name": "Hero Banner",
+    "category": "layout",
+    "description": "Full-width hero section with heading and call-to-action",
+    "cognitiveLoad": 3,
+    "usagePatterns": {
+      "do": ["Single clear CTA above the fold"],
+      "never": ["Multiple competing CTAs"]
+    }
+  },
+  "input": [],
+  "output": [],
+  "blocks": [
+    {
+      "id": "hero-heading",
+      "type": "heading",
+      "content": "Welcome",
+      "meta": { "level": 1 }
+    }
+  ]
+}

--- a/crates/veneer/src/commands/extract.rs
+++ b/crates/veneer/src/commands/extract.rs
@@ -1,9 +1,14 @@
 //! Extract documentation from a target project.
 
-use std::path::PathBuf;
+use std::fs;
+use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Args;
+use veneer_adapters::{
+    assess_coverage, not_yet_documented_placeholder, read_rafters_namespace, ComponentRegistry,
+    CoverageReport, CoverageState,
+};
 use veneer_docs::{
     generate_default_skeletons, generate_reference_pages, generate_sidebar, mark_required_flags,
     parse_cli_help, write_sidebar_jsonl, EditorialPage,
@@ -107,5 +112,165 @@ pub async fn run(args: ExtractArgs) -> Result<()> {
         args.output.display()
     );
 
+    // Phase 5: component coverage (FR-VEN-009). Measured against the
+    // discovered set; every uncovered item gets an explicit placeholder.
+    let coverage = run_coverage_phase(&args.project, &args.output, args.layout.as_deref())?;
+    tracing::info!(
+        "Emitted {} not-yet-documented placeholder pages",
+        coverage.placeholder_paths.len()
+    );
+    print_coverage_summary(&coverage.report);
+
     Ok(())
+}
+
+/// Outcome of the coverage phase: the report plus the placeholder pages
+/// that were emitted for uncovered items.
+struct CoverageOutcome {
+    report: CoverageReport,
+    placeholder_paths: Vec<PathBuf>,
+}
+
+/// Assess coverage against the discovered set and emit an explicit "not
+/// yet documented" placeholder page under `<output>/components/` for
+/// every uncovered item -- a real artifact, never a blank or a 404.
+fn run_coverage_phase(
+    project: &Path,
+    output: &Path,
+    layout: Option<&str>,
+) -> Result<CoverageOutcome> {
+    let source = read_rafters_namespace(project)
+        .with_context(|| format!("failed to read the rafters source in {}", project.display()))?;
+    let items = ComponentRegistry::discover(project, &source)
+        .with_context(|| format!("failed to discover components in {}", project.display()))?;
+    let assessed = assess_coverage(&items, &source);
+
+    let components_dir = output.join("components");
+    let mut placeholder_paths: Vec<PathBuf> = Vec::new();
+    for entry in &assessed {
+        let CoverageState::NotYetDocumented { reason } = &entry.state else {
+            continue;
+        };
+        let artifact = not_yet_documented_placeholder(&entry.item, reason, layout);
+        let path = components_dir.join(&artifact.file_name);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+        fs::write(&path, &artifact.content)
+            .with_context(|| format!("failed to write placeholder {}", path.display()))?;
+        placeholder_paths.push(path);
+    }
+
+    Ok(CoverageOutcome {
+        report: CoverageReport::from_assessed(&assessed),
+        placeholder_paths,
+    })
+}
+
+/// The queryable CLI coverage summary: exact counts against the
+/// discovered set, then each not-yet-documented item by name.
+fn print_coverage_summary(report: &CoverageReport) {
+    println!(
+        "Coverage: {} of {} discovered components documented, {} not yet documented",
+        report.documented.len(),
+        report.total,
+        report.not_yet_documented.len()
+    );
+    for name in &report.not_yet_documented {
+        println!("  not yet documented: {name}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A project with known partial coverage: Button renders, Broken does
+    /// not parse, and ghost-widget is installed with no source file.
+    fn partial_coverage_project() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let components = dir.path().join("components");
+        fs::create_dir_all(&components).expect("mkdir components");
+        fs::write(
+            components.join("button.tsx"),
+            "\
+const variantClasses = {
+  default: 'bg-primary text-primary-foreground',
+  secondary: 'bg-secondary text-secondary-foreground',
+};
+
+export function Button() {
+  return <button />;
+}
+",
+        )
+        .expect("write button");
+        fs::write(
+            components.join("broken.tsx"),
+            "const variantClasses = {\n  default: 'bg-primary',\n;\n\nexport function Broken( {\n",
+        )
+        .expect("write broken");
+
+        let rafters = dir.path().join(".rafters");
+        fs::create_dir_all(rafters.join("tokens")).expect("mkdir .rafters/tokens");
+        fs::write(
+            rafters.join("config.rafters.json"),
+            "{\"version\":\"1.0.0\",\"componentsPath\":\"components\",\
+             \"installed\":{\"components\":[\"ghost-widget\"],\"composites\":[]}}",
+        )
+        .expect("write config");
+        fs::write(
+            rafters.join("tokens/semantic.rafters.json"),
+            "{\"namespace\":\"semantic\",\"tokens\":[{\"name\":\"primary\",\
+             \"value\":\"oklch(0.6 0.2 25)\"}]}",
+        )
+        .expect("write tokens");
+        dir
+    }
+
+    // AC: the CLI-facing summary reports exact numbers against the
+    // discovered set of a fixture with known partial coverage.
+    #[test]
+    fn coverage_phase_reports_exact_numbers() {
+        let project = partial_coverage_project();
+        let output = tempfile::tempdir().expect("output dir");
+
+        let outcome = run_coverage_phase(project.path(), output.path(), None)
+            .expect("coverage phase must run");
+        let report = &outcome.report;
+        assert_eq!(report.total, 3);
+        assert_eq!(report.documented, ["Button"]);
+        assert_eq!(report.not_yet_documented, ["Broken", "ghost-widget"]);
+    }
+
+    // AC: every uncovered item gets an explicit "not yet documented"
+    // artifact on disk; documented items get no placeholder.
+    #[test]
+    fn coverage_phase_emits_a_placeholder_per_gap_and_only_per_gap() {
+        let project = partial_coverage_project();
+        let output = tempfile::tempdir().expect("output dir");
+
+        let outcome = run_coverage_phase(project.path(), output.path(), Some("../Docs.astro"))
+            .expect("coverage phase must run");
+
+        let components_dir = output.path().join("components");
+        assert_eq!(
+            outcome.placeholder_paths,
+            [
+                components_dir.join("broken.mdx"),
+                components_dir.join("ghost-widget.mdx"),
+            ]
+        );
+        for path in &outcome.placeholder_paths {
+            let content = fs::read_to_string(path).expect("placeholder must exist");
+            assert!(!content.trim().is_empty(), "never a blank page");
+            assert!(content.contains("status: not-yet-documented"));
+            assert!(content.contains("layout: ../Docs.astro"));
+        }
+        assert!(
+            !components_dir.join("button.mdx").exists(),
+            "a documented component gets no placeholder"
+        );
+    }
 }

--- a/crates/veneer/src/commands/extract.rs
+++ b/crates/veneer/src/commands/extract.rs
@@ -143,7 +143,7 @@ fn run_coverage_phase(
         .with_context(|| format!("failed to read the rafters source in {}", project.display()))?;
     let items = ComponentRegistry::discover(project, &source)
         .with_context(|| format!("failed to discover components in {}", project.display()))?;
-    let assessed = assess_coverage(&items, &source);
+    let assessed = assess_coverage(items, &source);
 
     let components_dir = output.join("components");
     let mut placeholder_paths: Vec<PathBuf> = Vec::new();
@@ -186,47 +186,13 @@ fn print_coverage_summary(report: &CoverageReport) {
 mod tests {
     use super::*;
 
-    /// A project with known partial coverage: Button renders, Broken does
-    /// not parse, and ghost-widget is installed with no source file.
-    fn partial_coverage_project() -> tempfile::TempDir {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let components = dir.path().join("components");
-        fs::create_dir_all(&components).expect("mkdir components");
-        fs::write(
-            components.join("button.tsx"),
-            "\
-const variantClasses = {
-  default: 'bg-primary text-primary-foreground',
-  secondary: 'bg-secondary text-secondary-foreground',
-};
-
-export function Button() {
-  return <button />;
-}
-",
-        )
-        .expect("write button");
-        fs::write(
-            components.join("broken.tsx"),
-            "const variantClasses = {\n  default: 'bg-primary',\n;\n\nexport function Broken( {\n",
-        )
-        .expect("write broken");
-
-        let rafters = dir.path().join(".rafters");
-        fs::create_dir_all(rafters.join("tokens")).expect("mkdir .rafters/tokens");
-        fs::write(
-            rafters.join("config.rafters.json"),
-            "{\"version\":\"1.0.0\",\"componentsPath\":\"components\",\
-             \"installed\":{\"components\":[\"ghost-widget\"],\"composites\":[]}}",
-        )
-        .expect("write config");
-        fs::write(
-            rafters.join("tokens/semantic.rafters.json"),
-            "{\"namespace\":\"semantic\",\"tokens\":[{\"name\":\"primary\",\
-             \"value\":\"oklch(0.6 0.2 25)\"}]}",
-        )
-        .expect("write tokens");
-        dir
+    /// The committed fixture with known partial coverage (shared with the
+    /// veneer-adapters coverage tests, so the two layers cannot drift):
+    /// Button renders, Broken does not parse, and ghost-widget is
+    /// installed with no source file.
+    fn partial_coverage_project() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../veneer-adapters/tests/fixtures/coverage/partial")
     }
 
     // AC: the CLI-facing summary reports exact numbers against the
@@ -236,8 +202,8 @@ export function Button() {
         let project = partial_coverage_project();
         let output = tempfile::tempdir().expect("output dir");
 
-        let outcome = run_coverage_phase(project.path(), output.path(), None)
-            .expect("coverage phase must run");
+        let outcome =
+            run_coverage_phase(&project, output.path(), None).expect("coverage phase must run");
         let report = &outcome.report;
         assert_eq!(report.total, 3);
         assert_eq!(report.documented, ["Button"]);
@@ -251,7 +217,7 @@ export function Button() {
         let project = partial_coverage_project();
         let output = tempfile::tempdir().expect("output dir");
 
-        let outcome = run_coverage_phase(project.path(), output.path(), Some("../Docs.astro"))
+        let outcome = run_coverage_phase(&project, output.path(), Some("../Docs.astro"))
             .expect("coverage phase must run");
 
         let components_dir = output.path().join("components");

--- a/crates/veneer/src/commands/extract.rs
+++ b/crates/veneer/src/commands/extract.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use clap::Args;
 use veneer_adapters::{
     assess_coverage, not_yet_documented_placeholder, read_rafters_namespace, ComponentRegistry,
-    CoverageReport, CoverageState,
+    CoverageReport, CoverageState, PlaceholderArtifact, NOT_YET_DOCUMENTED_STATUS,
 };
 use veneer_docs::{
     generate_default_skeletons, generate_reference_pages, generate_sidebar, mark_required_flags,
@@ -134,6 +134,9 @@ struct CoverageOutcome {
 /// Assess coverage against the discovered set and emit an explicit "not
 /// yet documented" placeholder page under `<output>/components/` for
 /// every uncovered item -- a real artifact, never a blank or a 404.
+/// Placeholders from a previous run whose item is no longer a gap are
+/// removed first, so the pages on disk cannot drift from the reported
+/// numbers.
 fn run_coverage_phase(
     project: &Path,
     output: &Path,
@@ -145,13 +148,21 @@ fn run_coverage_phase(
         .with_context(|| format!("failed to discover components in {}", project.display()))?;
     let assessed = assess_coverage(items, &source);
 
+    let artifacts: Vec<PlaceholderArtifact> = assessed
+        .iter()
+        .filter_map(|entry| match &entry.state {
+            CoverageState::NotYetDocumented { reason } => {
+                Some(not_yet_documented_placeholder(&entry.item, reason, layout))
+            }
+            CoverageState::Documented => None,
+        })
+        .collect();
+
     let components_dir = output.join("components");
+    remove_stale_placeholders(&components_dir, &artifacts)?;
+
     let mut placeholder_paths: Vec<PathBuf> = Vec::new();
-    for entry in &assessed {
-        let CoverageState::NotYetDocumented { reason } = &entry.state else {
-            continue;
-        };
-        let artifact = not_yet_documented_placeholder(&entry.item, reason, layout);
+    for artifact in &artifacts {
         let path = components_dir.join(&artifact.file_name);
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)
@@ -166,6 +177,44 @@ fn run_coverage_phase(
         report: CoverageReport::from_assessed(&assessed),
         placeholder_paths,
     })
+}
+
+/// Remove placeholder pages a previous run left behind for items that are
+/// no longer in the not-yet-documented set (fixed, or gone from the
+/// discovered set), so a stale "not yet documented" claim never survives
+/// a re-run. Only pages this phase owns are candidates: `.mdx` files
+/// whose frontmatter carries the placeholder status marker. Real
+/// documentation pages are never touched.
+fn remove_stale_placeholders(components_dir: &Path, current: &[PlaceholderArtifact]) -> Result<()> {
+    if !components_dir.is_dir() {
+        return Ok(());
+    }
+    let entries = fs::read_dir(components_dir)
+        .with_context(|| format!("failed to read {}", components_dir.display()))?;
+    for entry in entries {
+        let entry =
+            entry.with_context(|| format!("failed to read {}", components_dir.display()))?;
+        let path = entry.path();
+        let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if !file_name.ends_with(".mdx")
+            || current
+                .iter()
+                .any(|artifact| artifact.file_name == file_name)
+        {
+            continue;
+        }
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        if !content.contains(NOT_YET_DOCUMENTED_STATUS) {
+            continue;
+        }
+        fs::remove_file(&path)
+            .with_context(|| format!("failed to remove stale placeholder {}", path.display()))?;
+    }
+    Ok(())
 }
 
 /// The queryable CLI coverage summary: exact counts against the
@@ -188,8 +237,8 @@ mod tests {
 
     /// The committed fixture with known partial coverage (shared with the
     /// veneer-adapters coverage tests, so the two layers cannot drift):
-    /// Button renders, Broken does not parse, and ghost-widget is
-    /// installed with no source file.
+    /// Button renders, the hero-banner composite manifest renders, Broken
+    /// does not parse, and ghost-widget is installed with no source file.
     fn partial_coverage_project() -> PathBuf {
         Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../veneer-adapters/tests/fixtures/coverage/partial")
@@ -205,8 +254,8 @@ mod tests {
         let outcome =
             run_coverage_phase(&project, output.path(), None).expect("coverage phase must run");
         let report = &outcome.report;
-        assert_eq!(report.total, 3);
-        assert_eq!(report.documented, ["Button"]);
+        assert_eq!(report.total, 4);
+        assert_eq!(report.documented, ["Button", "hero-banner"]);
         assert_eq!(report.not_yet_documented, ["Broken", "ghost-widget"]);
     }
 
@@ -237,6 +286,59 @@ mod tests {
         assert!(
             !components_dir.join("button.mdx").exists(),
             "a documented component gets no placeholder"
+        );
+        assert!(
+            !components_dir.join("hero-banner.mdx").exists(),
+            "a documented composite gets no placeholder"
+        );
+    }
+
+    // A placeholder left by a previous run for an item that is no longer
+    // a gap must be removed on re-run, while real documentation pages in
+    // the same directory are never touched.
+    #[test]
+    fn coverage_phase_removes_stale_placeholders_but_not_real_pages() {
+        let project = partial_coverage_project();
+        let output = tempfile::tempdir().expect("output dir");
+        let components_dir = output.path().join("components");
+        fs::create_dir_all(&components_dir).expect("components dir");
+
+        // A stale placeholder from a prior run: its item ("Vanished") is
+        // not in the current discovered set, so its claim is now false.
+        let stale = not_yet_documented_placeholder(
+            &veneer_adapters::DiscoveredItem {
+                name: "Vanished".to_string(),
+                kind: veneer_adapters::DiscoveredKind::Component,
+                source_path: PathBuf::from("components/vanished.tsx"),
+                generated: false,
+            },
+            "it used to be broken",
+            None,
+        );
+        let stale_path = components_dir.join(&stale.file_name);
+        fs::write(&stale_path, &stale.content).expect("stale placeholder");
+
+        // A real documentation page (no placeholder marker) must survive.
+        let real_page = components_dir.join("button.mdx");
+        fs::write(&real_page, "---\ntitle: Button\n---\n\n# Button\n").expect("real page");
+
+        let outcome =
+            run_coverage_phase(&project, output.path(), None).expect("coverage phase must run");
+
+        assert!(
+            !stale_path.exists(),
+            "a stale placeholder must not survive a re-run"
+        );
+        assert!(
+            real_page.exists(),
+            "a real documentation page is never removed"
+        );
+        assert_eq!(
+            outcome.placeholder_paths,
+            [
+                components_dir.join("broken.mdx"),
+                components_dir.join("ghost-widget.mdx"),
+            ]
         );
     }
 }


### PR DESCRIPTION
Closes #74 (FR-VEN-009).

Veneer now tracks which discovered components are documented versus not yet,
reports the numbers from the `veneer extract` summary, and emits a real
"not yet documented" MDX page for every gap -- never a blank or a 404.

## Acceptance criteria mapping

### Coverage status is queryable, with the discovered set as the denominator

`CoverageReport { documented, not_yet_documented, total }` lives in the new
module `crates/veneer-adapters/src/coverage.rs:33`, and
`ComponentRegistry::coverage(project_root, source)` at coverage.rs:125 is the
queryable entry point: it calls `ComponentRegistry::discover` (FR-VEN-017)
and folds every discovered item -- and only discovered items -- into exactly
one bucket, so `total` is always the size of the discovered set
(`CoverageReport::from_assessed`, coverage.rs:47). The CLI surface is
`print_coverage_summary` in `crates/veneer/src/commands/extract.rs:222`,
printed at the end of every `veneer extract` run: exact counts plus each
uncovered item by name. Tests:
`coverage::tests::coverage_is_queryable_from_the_registry` (asserts total ==
documented + not_yet_documented against the fixture) and
`commands::extract::tests::coverage_phase_reports_exact_numbers`.

Note on the spec signature: the issue sketches `pub fn coverage(&self)`. The
registry's `&self` cache (registry.rs:35-38) only holds successfully
extracted components, so a `&self` method would silently shrink the
denominator below the discovered set and break the honest-numbers
requirement. `coverage` is therefore an associated function that works from
the project source, like `discover` itself; the rationale is in the doc
comment at coverage.rs:119-124.

### An undocumented component surfaces an explicit "not yet documented" artifact

`not_yet_documented_placeholder` (coverage.rs:157) builds a
`PlaceholderArtifact` (coverage.rs:145): a complete MDX page with
frontmatter (`status: not-yet-documented`), a heading, where the item was
discovered, and the honest reason it is not documented. `run_coverage_phase`
(extract.rs:140) writes one under `<output>/components/<kebab-name>.mdx` for
every uncovered item, alongside the generator's output family. Before
writing, `remove_stale_placeholders` (extract.rs:188) deletes placeholder
pages a previous run left behind for items that are no longer gaps -- keyed
on the `NOT_YET_DOCUMENTED_STATUS` frontmatter marker (coverage.rs:140), so
real documentation pages are never touched and the pages on disk cannot
drift from the reported numbers. Tests:
`coverage::tests::placeholder_is_a_real_explicit_artifact` (frontmatter,
heading, reason, and a never-blank line-count assertion),
`commands::extract::tests::coverage_phase_emits_a_placeholder_per_gap_and_only_per_gap`
(a placeholder per gap on disk, none for documented components), and
`commands::extract::tests::coverage_phase_removes_stale_placeholders_but_not_real_pages`.
I also drove the built binary against the committed fixture: it printed
"Coverage: 2 of 4 discovered components documented, 2 not yet documented"
and wrote broken.mdx and ghost-widget.mdx with full content.

### A component that failed generation counts as not-yet-documented, never as documented

`assess_item` (coverage.rs:106) has one criterion: `render_component` must
return Ok -- the render pipeline actually produced the item's preview. Any
render error lands the item in `CoverageState::NotYetDocumented { reason }`
carrying the failure state; there is no partial-success path to
`Documented`. Discovery's `DiscoveredItem::generated` flag is deliberately
not a gate: composite manifests are discovered with `generated: false` yet
render through the manifest path, so gating on the flag would mis-bucket
every composite and report a false reason (doc comments at coverage.rs:10-14
and coverage.rs:88-92). Tests:
`coverage::tests::failed_generation_is_not_yet_documented_with_its_failure_state`
(the unparseable broken.tsx carries a reason naming its source),
`coverage::tests::render_failure_is_never_documented` (an item discovery
marked generatable whose render then fails is still not documented), and
`coverage::tests::composite_manifest_counts_as_documented_despite_generated_false`
(the regression guard for the flag rationale above).

### Coverage numbers are exact against a fixture with known partial coverage

The committed fixture
`crates/veneer-adapters/tests/fixtures/coverage/partial/` discovers exactly
four items: Button (renderable source), hero-banner (renderable composite
manifest), Broken (unparseable TSX), and ghost-widget (listed in
`installed.components` of the rafters config with no source file).
`coverage::tests::coverage_numbers_are_exact_against_partial_fixture`
asserts total == 4, documented == ["Button", "hero-banner"],
not_yet_documented == ["Broken", "ghost-widget"] -- exact lists, not
thresholds. The CLI-layer test
`commands::extract::tests::coverage_phase_reports_exact_numbers` asserts the
same exact numbers through `run_coverage_phase`, reusing the same committed
fixture so the two layers cannot drift.

### All types explicit; Result for fallible operations

Coverage state is the enum `CoverageState` (coverage.rs:68), not a bool or a
string, and every public struct field is typed in the source
(`CoverageReport` at coverage.rs:33, `PlaceholderArtifact` at
coverage.rs:145, `AssessedItem` at coverage.rs:78). The fallible operations
return `Result`: `ComponentRegistry::coverage` returns
`Result<CoverageReport, RegistryError>` (coverage.rs:125), and
`run_coverage_phase` returns `Result<CoverageOutcome>` (extract.rs:140) with
`with_context` on the namespace read, discovery, directory creation, stale
placeholder removal, and every placeholder write.

### No unwrap() in production code

The new production code contains no `unwrap()`: `assess_item` matches on the
`render_component` result (coverage.rs:107-112), the placeholder builder's
only option handling is `map(...).unwrap_or_default()` on the optional
layout line (coverage.rs:162-164), and the CLI phase propagates errors with
`?`. The only `expect` calls in the diff are inside `#[cfg(test)]` modules.
`cargo clippy --workspace --all-targets -- -D warnings` passing (below) also
enforces the workspace lint surface over the new module.

### clippy and fmt clean

`cargo clippy --workspace --all-targets -- -D warnings`,
`cargo fmt -- --check`, and `cargo test --workspace` (157 tests) all pass on
this branch.

## Also in this diff

The placeholder file naming needed the same kebab-casing
`preview_tag_name` already had, so that logic moved to a shared
`kebab_case` helper in `crates/veneer-adapters/src/ts_helpers.rs:9` and
`intelligence.rs` now calls it (intelligence.rs:334) instead of carrying
its own copy -- one implementation, two callers, no behavior change.

## What I deliberately did not do

- Did not close the coverage gap itself: no generation work for Broken or
  ghost-widget. That is FR-VEN-003 per component, excluded by the issue.
- Did not add staleness or freshness marking (FR-VEN-014); coverage and
  freshness stay distinct states, so the placeholder frontmatter carries only
  `status: not-yet-documented`.
- Did not touch `crates/veneer-adapters/src/registry.rs`: coverage lives in a
  new module (`coverage.rs`) that builds on `DiscoveredItem` and
  `render_component`, keeping the diff out of files sibling branches are
  editing.
- Did not make the extract command fail on projects without a `.rafters`
  tree: verified by running the binary against a bare directory -- it reports
  0 of 0 and exits 0, so CLI-docs-only projects keep working.